### PR TITLE
Fixes and hardening, several issues addressed

### DIFF
--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManager.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManager.java
@@ -70,18 +70,6 @@ public class DiscoveryManager
         boolean onPermissionCheckRequired(String permission);
 
         /**
-         * Called when Wi-Fi is enabled/disabled.
-         * @param isEnabled True, if enabled. False, if disabled.
-         */
-        void onWifiEnabledChanged(boolean isEnabled);
-
-        /**
-         * Called when Bluetooth is enabled/disabled.
-         * @param isEnabled True, if enabled. False, if disabled.
-         */
-        void onBluetoothEnabledChanged(boolean isEnabled);
-
-        /**
          * Called when the state of this instance is changed.
          * @param state The new state.
          * @param isDiscovering True, if peer discovery is active. False otherwise.
@@ -594,13 +582,6 @@ public class DiscoveryManager
                 }
             }
         }
-
-        mHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                mListener.onBluetoothEnabledChanged(isBluetoothEnabled);
-            }
-        });
     }
 
     /**
@@ -637,13 +618,6 @@ public class DiscoveryManager
                 }
             }
         }
-
-        mHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                mListener.onWifiEnabledChanged(isWifiEnabled);
-            }
-        });
     }
 
     /**

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothConnector.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothConnector.java
@@ -506,7 +506,6 @@ public class BluetoothConnector
     public void onBluetoothServerSocketConsecutiveCreationFailureCountLimitExceeded(int limit) {
         Log.e(TAG, "onBluetoothServerSocketConsecutiveCreationFailureCountLimitExceeded: Failed " + limit + " times");
         stopListeningForIncomingConnections();
-
     }
 
     /**

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothConnector.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothConnector.java
@@ -502,6 +502,13 @@ public class BluetoothConnector
         }
     }
 
+    @Override
+    public void onBluetoothServerSocketConsecutiveCreationFailureCountLimitExceeded(int limit) {
+        Log.e(TAG, "onBluetoothServerSocketConsecutiveCreationFailureCountLimitExceeded: Failed " + limit + " times");
+        stopListeningForIncomingConnections();
+
+    }
+
     /**
      * Does nothing but logs the event.
      *

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BlePeerDiscoveryUtils.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BlePeerDiscoveryUtils.java
@@ -421,9 +421,14 @@ class BlePeerDiscoveryUtils {
         int[] intArray = null;
 
         if (hexStringArray.length >= BluetoothUtils.BLUETOOTH_ADDRESS_BYTE_COUNT) {
-            intArray = new int[hexStringArray.length];
+            if (hexStringArray.length > BluetoothUtils.BLUETOOTH_ADDRESS_BYTE_COUNT) {
+                Log.w(TAG, "bluetoothAddressToInt8Array: The given Bluetooth address (\""
+                        + bluetoothAddress + "\") might be invalid since it seems to have too many bytes. Will only use the first six bytes.");
+            }
 
-            for (int i = 0; i < hexStringArray.length; ++i) {
+            intArray = new int[BluetoothUtils.BLUETOOTH_ADDRESS_BYTE_COUNT];
+
+            for (int i = 0; i < BluetoothUtils.BLUETOOTH_ADDRESS_BYTE_COUNT; ++i) {
                 try {
                     intArray[i] = Integer.parseInt(hexStringArray[i], 16);
                 } catch (NumberFormatException e) {

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BlePeerDiscoveryUtils.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BlePeerDiscoveryUtils.java
@@ -444,16 +444,12 @@ class BlePeerDiscoveryUtils {
      * @return The parsed Bluetooth address.
      */
     private static String int8ArrayToBluetoothAddress(int[] bluetoothAddressAsInt8Array) {
-        StringBuilder stringBuilder = new StringBuilder();
-
-        for (int i = 0; i < bluetoothAddressAsInt8Array.length; ++i) {
-            stringBuilder.append(Integer.toHexString(bluetoothAddressAsInt8Array[i] & 0xff));
-
-            if (i < bluetoothAddressAsInt8Array.length - 1) {
-                stringBuilder.append(BLUETOOTH_ADDRESS_SEPARATOR);
-            }
-        }
-
-        return stringBuilder.toString().toUpperCase();
+        return String.format("%02X:%02X:%02X:%02X:%02X:%02X",
+                (bluetoothAddressAsInt8Array[0] & 0xff),
+                (bluetoothAddressAsInt8Array[1] & 0xff),
+                (bluetoothAddressAsInt8Array[2] & 0xff),
+                (bluetoothAddressAsInt8Array[3] & 0xff),
+                (bluetoothAddressAsInt8Array[4] & 0xff),
+                (bluetoothAddressAsInt8Array[5] & 0xff));
     }
 }

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BlePeerDiscoveryUtils.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BlePeerDiscoveryUtils.java
@@ -420,12 +420,7 @@ class BlePeerDiscoveryUtils {
         String[] hexStringArray = bluetoothAddress.split(BLUETOOTH_ADDRESS_SEPARATOR);
         int[] intArray = null;
 
-        if (hexStringArray.length >= BluetoothUtils.BLUETOOTH_ADDRESS_BYTE_COUNT) {
-            if (hexStringArray.length > BluetoothUtils.BLUETOOTH_ADDRESS_BYTE_COUNT) {
-                Log.w(TAG, "bluetoothAddressToInt8Array: The given Bluetooth address (\""
-                        + bluetoothAddress + "\") might be invalid since it seems to have too many bytes. Will only use the first six bytes.");
-            }
-
+        if (hexStringArray.length == BluetoothUtils.BLUETOOTH_ADDRESS_BYTE_COUNT) {
             intArray = new int[BluetoothUtils.BLUETOOTH_ADDRESS_BYTE_COUNT];
 
             for (int i = 0; i < BluetoothUtils.BLUETOOTH_ADDRESS_BYTE_COUNT; ++i) {
@@ -437,6 +432,9 @@ class BlePeerDiscoveryUtils {
                     break;
                 }
             }
+        } else {
+            Log.e(TAG, "bluetoothAddressToInt8Array: The byte count of the given address is invalid - got "
+                    + hexStringArray.length + ", but was expecting " + BluetoothUtils.BLUETOOTH_ADDRESS_BYTE_COUNT + " bytes");
         }
 
         return intArray;

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/PeerAdvertisementFactory.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/PeerAdvertisementFactory.java
@@ -62,6 +62,9 @@ class PeerAdvertisementFactory {
                 serviceDataAsByteArray[i + 1] = bluetoothMacAddressAsByteArray[i];
             }
 
+            Log.v(TAG, "createAdvertiseDataToServiceData: Service data (length is "
+                    + serviceDataAsByteArray.length + " bytes): " + new String(serviceDataAsByteArray));
+
             try {
                 builder.addServiceData(serviceUuidAsParcelUuid, serviceDataAsByteArray);
                 advertiseData = builder.build();

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/PeerAdvertisementFactory.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/PeerAdvertisementFactory.java
@@ -9,6 +9,8 @@ import android.os.ParcelUuid;
 import android.util.Log;
 import org.thaliproject.p2p.btconnectorlib.PeerProperties;
 import org.thaliproject.p2p.btconnectorlib.internal.bluetooth.BluetoothUtils;
+import org.thaliproject.p2p.btconnectorlib.utils.CommonUtils;
+
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -63,7 +65,8 @@ class PeerAdvertisementFactory {
             }
 
             Log.v(TAG, "createAdvertiseDataToServiceData: Service data (length is "
-                    + serviceDataAsByteArray.length + " bytes): " + new String(serviceDataAsByteArray));
+                    + serviceDataAsByteArray.length + " bytes): "
+                    + CommonUtils.byteArrayToHexString(serviceDataAsByteArray, true));
 
             try {
                 builder.addServiceData(serviceUuidAsParcelUuid, serviceDataAsByteArray);

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/wifi/WifiDirectManager.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/wifi/WifiDirectManager.java
@@ -144,20 +144,22 @@ public class WifiDirectManager {
      * If false is returned, this could indicate the lack of Wi-Fi Direct hardware support.
      */
     private synchronized boolean initialize() {
-        if (!mInitialized && isWifiDirectSupported()) {
+        if (!mInitialized) {
             mWifiStateBroadcastReceiver = new WifiStateBroadcastReceiver();
             IntentFilter filter = new IntentFilter();
             filter.addAction(WifiP2pManager.WIFI_P2P_STATE_CHANGED_ACTION);
 
             try {
                 mContext.registerReceiver(mWifiStateBroadcastReceiver, filter);
+                mInitialized = true;
             } catch (IllegalArgumentException e) {
                 Log.e(TAG, "initialize: Failed to register the broadcast receiver: " + e.getMessage(), e);
                 mWifiStateBroadcastReceiver = null;
             }
 
-            mP2pChannel = mP2pManager.initialize(mContext, mContext.getMainLooper(), null);
-            mInitialized = true;
+            if (isWifiDirectSupported()) {
+                mP2pChannel = mP2pManager.initialize(mContext, mContext.getMainLooper(), null);
+            }
         }
 
         return mInitialized;

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/utils/CommonUtils.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/utils/CommonUtils.java
@@ -16,6 +16,7 @@ import org.thaliproject.p2p.btconnectorlib.internal.bluetooth.BluetoothUtils;
  */
 public class CommonUtils {
     private static final String TAG = CommonUtils.class.getName();
+    private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
     /**
      * @return True, if we are running on Lollipop (Android version 5.x, API level 21) or higher.
@@ -83,5 +84,44 @@ public class CommonUtils {
         byte[] message = new byte[1];
         message[0] = (byte) 0x0;
         return message;
+    }
+
+    /**
+     * Converts the content of the given byte array to hex string.
+     *
+     * @param bytes The bytes to convert.
+     * @return The bytes as hex string.
+     */
+    public static String byteArrayToHexString(byte[] bytes, boolean addSpacesBetweenBytes) {
+        String hexString = null;
+
+        if (bytes != null && bytes.length > 0) {
+            char[] hexCharArray = new char[bytes.length * 2];
+
+            for (int i = 0; i < bytes.length; i++) {
+                int v = bytes[i] & 0xFF;
+                hexCharArray[i * 2] = HEX_ARRAY[v >>> 4];
+                hexCharArray[i * 2 + 1] = HEX_ARRAY[v & 0x0F];
+            }
+
+            if (addSpacesBetweenBytes) {
+                StringBuilder stringBuilder = new StringBuilder();
+
+                for (int i = 0; i < hexCharArray.length; i += 2) {
+                    stringBuilder.append(hexCharArray[i]);
+                    stringBuilder.append(hexCharArray[i + 1]);
+
+                    if (i < hexCharArray.length - 2) {
+                        stringBuilder.append(" ");
+                    }
+
+                    hexString = stringBuilder.toString();
+                }
+            } else {
+                hexString = new String(hexCharArray);
+            }
+        }
+
+        return hexString;
     }
 }

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/utils/CommonUtils.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/utils/CommonUtils.java
@@ -90,6 +90,7 @@ public class CommonUtils {
      * Converts the content of the given byte array to hex string.
      *
      * @param bytes The bytes to convert.
+     * @param addSpacesBetweenBytes If true, will add spaces between the bytes in the string.
      * @return The bytes as hex string.
      */
     public static String byteArrayToHexString(byte[] bytes, boolean addSpacesBetweenBytes) {

--- a/BtConnectorLib/settings.gradle
+++ b/BtConnectorLib/settings.gradle
@@ -1,3 +1,3 @@
 include ':btconnectorlib2'
-gradle.ext.version = "0.2.7";
+gradle.ext.version = "0.2.9";
 gradle.ext.group = "org.thaliproject.p2p.btconnectorlib"

--- a/BtConnectorLib/settings.gradle
+++ b/BtConnectorLib/settings.gradle
@@ -1,3 +1,3 @@
 include ':btconnectorlib2'
-gradle.ext.version = "0.2.6";
+gradle.ext.version = "0.2.7";
 gradle.ext.group = "org.thaliproject.p2p.btconnectorlib"

--- a/NativeTestApp/app/build.gradle
+++ b/NativeTestApp/app/build.gradle
@@ -39,5 +39,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile(group: 'org.thaliproject.p2p.btconnectorlib', name: 'btconnectorlib2', version: '0.2.7', ext: 'aar')
+    compile(group: 'org.thaliproject.p2p.btconnectorlib', name: 'btconnectorlib2', version: '0.2.9', ext: 'aar')
 }

--- a/NativeTestApp/app/build.gradle
+++ b/NativeTestApp/app/build.gradle
@@ -39,5 +39,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile(group: 'org.thaliproject.p2p.btconnectorlib', name: 'btconnectorlib2', version: '0.2.6', ext: 'aar')
+    compile(group: 'org.thaliproject.p2p.btconnectorlib', name: 'btconnectorlib2', version: '0.2.7', ext: 'aar')
 }

--- a/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/ConnectionEngine.java
+++ b/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/ConnectionEngine.java
@@ -401,22 +401,6 @@ public class ConnectionEngine implements
     }
 
     /**
-     * @param isEnabled True, if enabled. False, if disabled.
-     */
-    @Override
-    public void onWifiEnabledChanged(boolean isEnabled) {
-        Log.d(TAG, "onWifiEnabledChanged: " + isEnabled);
-    }
-
-    /**
-     * @param isEnabled True, if enabled. False, if disabled.
-     */
-    @Override
-    public void onBluetoothEnabledChanged(boolean isEnabled) {
-        Log.d(TAG, "onBluetoothEnabledChanged: " + isEnabled);
-    }
-
-    /**
      * @param state The new state.
      * @param isDiscovering True, if peer discovery is active. False otherwise.
      * @param isAdvertising True, if advertising is active. False otherwise.

--- a/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/fragments/PeerListFragment.java
+++ b/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/fragments/PeerListFragment.java
@@ -195,7 +195,7 @@ public class PeerListFragment extends Fragment implements PeerAndConnectionModel
     }
 
     @Override
-    public void onDataChanged() {
+    public synchronized void onDataChanged() {
         Log.i(TAG, "onDataChanged");
         Handler handler = new Handler(mContext.getMainLooper());
 
@@ -208,7 +208,7 @@ public class PeerListFragment extends Fragment implements PeerAndConnectionModel
     }
 
     @Override
-    public void onPeerRemoved(final PeerProperties peerProperties) {
+    public synchronized void onPeerRemoved(final PeerProperties peerProperties) {
         Log.i(TAG, "onPeerRemoved: " + peerProperties);
         final boolean peerRemovedWasSelected;
 

--- a/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/test/FindMyBluetoothAddressTest.java
+++ b/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/test/FindMyBluetoothAddressTest.java
@@ -93,16 +93,6 @@ public class FindMyBluetoothAddressTest
     }
 
     @Override
-    public void onWifiEnabledChanged(boolean isEnabled) {
-        // Not used
-    }
-
-    @Override
-    public void onBluetoothEnabledChanged(boolean isEnabled) {
-        // Not used
-    }
-
-    @Override
     public void onDiscoveryManagerStateChanged(
             DiscoveryManager.DiscoveryManagerState state,
             boolean isDiscovering, boolean isAdvertising) {

--- a/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/test/FindPeersTest.java
+++ b/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/test/FindPeersTest.java
@@ -63,16 +63,6 @@ public class FindPeersTest extends AbstractTest implements DiscoveryManager.Disc
     }
 
     @Override
-    public void onWifiEnabledChanged(boolean isEnabled) {
-        // Not used
-    }
-
-    @Override
-    public void onBluetoothEnabledChanged(boolean isEnabled) {
-        // Not used
-    }
-
-    @Override
     public void onDiscoveryManagerStateChanged(
             DiscoveryManager.DiscoveryManagerState state,
             boolean isDiscovering, boolean isAdvertising) {


### PR DESCRIPTION
- Possible fix to #49: Auto-connect shouldn't now happen when disconnected during closing of the app.
- Fixed #50: Added @RoundSparrow's fix for int8ArrayToBluetoothAddress method.
- Possible fix to #51: Method calling `notifyDataSetChanged` in `PeerListFragment` are now synchronous.
- Fixed #53: If the creation of Bluetooth server socket now fails consecutively 10 times, the connection manager is stopped.
- Updated the BtConnectorLib version number from 0.2.6 to 0.2.7.
- Minor fix: The service data is now printed as hex string in the logs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin_btlibrary/54)

<!-- Reviewable:end -->

<!---
@huboard:{"order":5.5849552154541016e-05,"milestone_order":54,"custom_state":""}
-->
