### PR TITLE
Fix for service data issue seen on some devices

### DIFF
--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/ConnectionManager.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/ConnectionManager.java
@@ -347,9 +347,9 @@ public class ConnectionManager
     @Override
     public void onConnectionTimeout(final PeerProperties peerProperties) {
         if (peerProperties != null) {
-            Log.w(TAG, "onConnectionTimeout: Connection attempt with peer " + peerProperties + " timed out");
+            Log.e(TAG, "onConnectionTimeout: Connection attempt with peer " + peerProperties + " timed out");
         } else {
-            Log.w(TAG, "onConnectionTimeout");
+            Log.e(TAG, "onConnectionTimeout");
         }
 
         if (mListener != null) {

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManager.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManager.java
@@ -71,6 +71,7 @@ public class DiscoveryManager
 
         /**
          * Called when the state of this instance is changed.
+         *
          * @param state The new state.
          * @param isDiscovering True, if peer discovery is active. False otherwise.
          * @param isAdvertising True, if advertising is active. False otherwise.
@@ -80,6 +81,7 @@ public class DiscoveryManager
 
         /**
          * Called when a new peer is discovered.
+         *
          * @param peerProperties The properties of the new peer.
          */
         void onPeerDiscovered(PeerProperties peerProperties);
@@ -87,12 +89,14 @@ public class DiscoveryManager
         /**
          * Called when a peer data is updated (missing data is added). This callback is never
          * called, if data is lost.
+         *
          * @param peerProperties The updated properties of a discovered peer.
          */
         void onPeerUpdated(PeerProperties peerProperties);
 
         /**
          * Called when an existing peer is lost (i.e. not available anymore).
+         *
          * @param peerProperties The properties of the lost peer.
          */
         void onPeerLost(PeerProperties peerProperties);
@@ -158,6 +162,7 @@ public class DiscoveryManager
 
     /**
      * Constructor.
+     *
      * @param context The application context.
      * @param listener The listener.
      * @param bleServiceUuid Our BLE service UUID (both ours and requirement for the peer).
@@ -225,6 +230,7 @@ public class DiscoveryManager
 
     /**
      * Checks the current state and returns true, if running regardless of the discovery mode in use.
+     *
      * @return True, if running regardless of the mode. False otherwise.
      */
     public boolean isRunning() {
@@ -289,6 +295,7 @@ public class DiscoveryManager
 
     /**
      * Used to check, if some required permission has not been granted by the user.
+     *
      * @return The name of the missing permission or null, if none.
      */
     public String getMissingPermission() {
@@ -297,6 +304,7 @@ public class DiscoveryManager
 
     /**
      * Starts the peer discovery.
+     *
      * @param startDiscovery If true, will start the scanner/discovery.
      * @param startAdvertising If true, will start the advertiser.
      * @return True, if started successfully or was already running. False otherwise.
@@ -440,6 +448,7 @@ public class DiscoveryManager
 
     /**
      * Makes the device (Bluetooth) discoverable for the given duration.
+     *
      * @param durationInSeconds The duration in seconds. 0 means the device is always discoverable.
      *                          Any value below 0 or above 3600 is automatically set to 120 secs.
      */
@@ -471,6 +480,7 @@ public class DiscoveryManager
 
     /**
      * Constructs the BlePeerDiscoverer instance, if one does not already exist.
+     *
      * @return The BlePeerDiscoverer instance.
      */
     public BlePeerDiscoverer getBlePeerDiscovererInstanceAndCheckBluetoothMacAddress() {
@@ -481,8 +491,7 @@ public class DiscoveryManager
                     mBluetoothManager.getBluetoothAdapter(),
                     mBleServiceUuid,
                     mBluetoothMacAddressResolutionHelper.getProvideBluetoothMacAddressRequestUuid(),
-                    getBluetoothMacAddress(),
-                    mSettings.getAdvertisementDataType());
+                    getBluetoothMacAddress(), mSettings.getAdvertisementDataType());
         }
 
         if (BluetoothUtils.isBluetoothMacAddressUnknown(mBlePeerDiscoverer.getBluetoothMacAddress())
@@ -496,6 +505,7 @@ public class DiscoveryManager
 
     /**
      * From DiscoveryManagerSettings.Listener
+     *
      * @param discoveryMode The new discovery mode.
      * @param startIfNotRunning If true, will start even if the discovery wasn't running.
      */
@@ -511,6 +521,7 @@ public class DiscoveryManager
 
     /**
      * From DiscoveryManagerSettings.Listener
+     *
      * @param peerExpirationInMilliseconds The new peer expiration time in milliseconds.
      */
     @Override
@@ -520,36 +531,41 @@ public class DiscoveryManager
 
     /**
      * From DiscoveryManagerSettings.Listener
+     *
+     * @param advertisementDataType The new advertisement data type.
+     */
+    @Override
+    public void onAdvertisementDataTypeChanged(BlePeerDiscoverer.AdvertisementDataType advertisementDataType) {
+        applyBleAdvertiserSettingsWhichRequireRestart();
+    }
+
+    /**
+     * From DiscoveryManagerSettings.Listener
+     *
      * @param advertiseMode The new advertise mode.
      * @param advertiseTxPowerLevel The new advertise TX power level.
      */
     @Override
     public void onAdvertiseSettingsChanged(int advertiseMode, int advertiseTxPowerLevel) {
-        if (mBlePeerDiscoverer != null) {
-            mBlePeerDiscoverer.applySettings(
-                    advertiseMode, advertiseTxPowerLevel,
-                    mSettings.getScanMode(), mSettings.getScanReportDelay());
-        }
+        applyBleAdvertiserSettingsWhichRequireRestart();
     }
 
     /**
      * From DiscoveryManagerSettings.Listener
+     *
      * @param scanMode The new scan mode.
      * @param scanReportDelayInMilliseconds The new scan report delay in milliseconds.
      */
     @Override
     public void onScanSettingsChanged(int scanMode, long scanReportDelayInMilliseconds) {
-        if (mBlePeerDiscoverer != null) {
-            mBlePeerDiscoverer.applySettings(
-                    mSettings.getAdvertiseMode(), mSettings.getAdvertiseTxPowerLevel(),
-                    scanMode, scanReportDelayInMilliseconds);
-        }
+        applyBleAdvertiserSettingsWhichRequireRestart();
     }
 
     /**
      * From BluetoothManager.BluetoothManagerListener
      *
      * Stops/restarts the BLE based peer discovery depending on the given mode and notifies the listener.
+     *
      * @param mode The new mode.
      */
     @Override
@@ -588,6 +604,7 @@ public class DiscoveryManager
      * From WifiDirectManager.WifiStateListener
      *
      * Stops/restarts the Wi-Fi Direct based peer discovery depending on the given state.
+     *
      * @param state The new state.
      */
     @Override
@@ -624,6 +641,7 @@ public class DiscoveryManager
      * From WifiPeerDiscoverer.WifiPeerDiscoveryListener
      *
      * Stores the new state and notifies the listener.
+     *
      * @param state The new state.
      */
     @Override
@@ -639,6 +657,7 @@ public class DiscoveryManager
      * From BlePeerDiscoverer.BlePeerDiscoveryListener
      *
      * Stores the new state and notifies the listener.
+     *
      * @param state The new state.
      */
     @Override
@@ -654,6 +673,7 @@ public class DiscoveryManager
      * From both WifiPeerDiscoverer.WifiPeerDiscoveryListener and BlePeerDiscoverer.BlePeerDiscoveryListener
      *
      * Adds or updates the discovered peer.
+     *
      * @param peerProperties The properties of the discovered peer.
      */
     @Override
@@ -666,6 +686,7 @@ public class DiscoveryManager
      * From WifiPeerDiscoverer.WifiPeerDiscoveryListener
      *
      * Updates the discovered peers, which match the ones on the given list.
+     *
      * @param p2pDeviceList A list containing the discovered P2P devices.
      */
     @Override
@@ -784,6 +805,7 @@ public class DiscoveryManager
      * Part of Bro Mode.
      *
      * Stores and forwards the resolved Bluetooth MAC address to the listener.
+     *
      * @param bluetoothMacAddress Our Bluetooth MAC address.
      */
     @Override
@@ -810,6 +832,7 @@ public class DiscoveryManager
      * Part of Bro Mode.
      *
      * Changes the state based on the given argument.
+     *
      * @param isStarted If true, was started. If false, was stopped.
      */
     @Override
@@ -833,6 +856,7 @@ public class DiscoveryManager
      * Part of Bro Mode.
      *
      * Changes the state based on the given argument.
+     *
      * @param isStarted If true, was started. If false, was stopped.
      */
     @Override
@@ -856,6 +880,7 @@ public class DiscoveryManager
      * From PeerModel.Listener
      *
      * Forwards the event to the listener.
+     *
      * @param peerProperties The properties of the added peer.
      */
     @Override
@@ -876,6 +901,7 @@ public class DiscoveryManager
      * From PeerModel.Listener
      *
      * Forwards the event to the listener.
+     *
      * @param peerProperties The properties of the updated peer.
      */
     @Override
@@ -894,6 +920,7 @@ public class DiscoveryManager
      * From PeerModel.Listener
      *
      * Forwards the event to the listener.
+     *
      * @param peerProperties The properties of the expired and removed peer.
      */
     @Override
@@ -922,6 +949,7 @@ public class DiscoveryManager
 
     /**
      * Tries to start the BLE peer discoverer.
+     *
      * @param startScanner If true, will start the scanner.
      * @param startAdvertising If true, will start the advertiser.
      * @return True, if started (or already running). False otherwise.
@@ -967,6 +995,7 @@ public class DiscoveryManager
 
     /**
      * Stops the BLE peer discoverer.
+     *
      * @param updateState If true, will update the state.
      */
     private synchronized void stopBlePeerDiscoverer(boolean updateState) {
@@ -988,6 +1017,7 @@ public class DiscoveryManager
     /**
      * Tries to start the Wi-Fi Direct based peer discovery.
      * Note that this method does not validate the current state nor the identity string.
+     *
      * @param startDiscoverer If true, will start the discoverer.
      * @param startAdvertising If true, will start the advertiser.
      * @return True, if started (or already running). False otherwise.
@@ -1030,6 +1060,7 @@ public class DiscoveryManager
 
     /**
      * Stops the Wi-Fi Direct based peer discovery.
+     *
      * @param updateState If true, will update the state.
      */
     private synchronized void stopWifiPeerDiscovery(boolean updateState) {
@@ -1049,7 +1080,20 @@ public class DiscoveryManager
     }
 
     /**
+     * Applies the current BLE advertiser settings that require the BLE advertiser to restart when changed.
+     */
+    private void applyBleAdvertiserSettingsWhichRequireRestart() {
+        if (mBlePeerDiscoverer != null) {
+            mBlePeerDiscoverer.applySettings(
+                    mSettings.getAdvertisementDataType(),
+                    mSettings.getAdvertiseMode(), mSettings.getAdvertiseTxPowerLevel(),
+                    mSettings.getScanMode(), mSettings.getScanReportDelay());
+        }
+    }
+
+    /**
      * Updates the state of this instance and notifies the listener.
+     *
      * @param state The new state.
      */
     private synchronized void updateState(final DiscoveryManagerState state) {

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManager.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManager.java
@@ -482,7 +482,7 @@ public class DiscoveryManager
                     mBleServiceUuid,
                     mBluetoothMacAddressResolutionHelper.getProvideBluetoothMacAddressRequestUuid(),
                     getBluetoothMacAddress(),
-                    BlePeerDiscoverer.AdvertisementDataType.SERVICE_DATA);
+                    mSettings.getAdvertisementDataType());
         }
 
         if (BluetoothUtils.isBluetoothMacAddressUnknown(mBlePeerDiscoverer.getBluetoothMacAddress())

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManagerSettings.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManagerSettings.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import org.thaliproject.p2p.btconnectorlib.DiscoveryManager.DiscoveryMode;
 import org.thaliproject.p2p.btconnectorlib.internal.AbstractSettings;
 import org.thaliproject.p2p.btconnectorlib.internal.bluetooth.BluetoothUtils;
+import org.thaliproject.p2p.btconnectorlib.internal.bluetooth.le.BlePeerDiscoverer.AdvertisementDataType;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -51,6 +52,7 @@ public class DiscoveryManagerSettings extends AbstractSettings {
     public static final int DEFAULT_DEVICE_DISCOVERABLE_DURATION_IN_SECONDS = (int)(DEFAULT_PROVIDE_BLUETOOTH_MAC_ADDRESS_TIMEOUT_IN_MILLISECONDS / 1000);
     public static final DiscoveryMode DEFAULT_DISCOVERY_MODE = DiscoveryMode.BLE;
     public static final long DEFAULT_PEER_EXPIRATION_IN_MILLISECONDS = 60000;
+    public static final AdvertisementDataType DEFAULT_ADVERTISEMENT_DATA_TYPE = AdvertisementDataType.MANUFACTURER_DATA;
     public static final int DEFAULT_ADVERTISE_MODE = AdvertiseSettings.ADVERTISE_MODE_BALANCED;
     public static final int DEFAULT_ADVERTISE_TX_POWER_LEVEL = AdvertiseSettings.ADVERTISE_TX_POWER_MEDIUM;
     public static final int DEFAULT_SCAN_MODE = ScanSettings.SCAN_MODE_BALANCED;
@@ -63,6 +65,7 @@ public class DiscoveryManagerSettings extends AbstractSettings {
     private static final String KEY_BLUETOOTH_MAC_ADDRESS = "bluetooth_mac_address";
     private static final String KEY_DISCOVERY_MODE = "discovery_mode";
     private static final String KEY_PEER_EXPIRATION = "peer_expiration";
+    private static final String KEY_ADVERTISEMENT_DATA_TYPE = "advertisement_data_type";
     private static final String KEY_ADVERTISE_MODE = "advertise_mode";
     private static final String KEY_ADVERTISE_TX_POWER_LEVEL = "advertise_tx_power_level";
     private static final String KEY_SCAN_MODE = "scan_mode";
@@ -73,6 +76,9 @@ public class DiscoveryManagerSettings extends AbstractSettings {
     private static final int DISCOVERY_MODE_WIFI = 1;
     private static final int DISCOVERY_MODE_BLE_AND_WIFI = 2;
 
+    private static final int ADVERTISEMENT_DATA_TYPE_SERVICE = 0;
+    private static final int ADVERTISEMENT_DATA_TYPE_MANUFACTURER = 1;
+
     private static final String TAG = DiscoveryManagerSettings.class.getName();
 
     private static DiscoveryManagerSettings mInstance = null;
@@ -81,6 +87,7 @@ public class DiscoveryManagerSettings extends AbstractSettings {
     private String mBluetoothMacAddress = null;
     private DiscoveryMode mDiscoveryMode = DEFAULT_DISCOVERY_MODE;
     private long mPeerExpirationInMilliseconds = DEFAULT_PEER_EXPIRATION_IN_MILLISECONDS;
+    private AdvertisementDataType mAdvertisementDataType = DEFAULT_ADVERTISEMENT_DATA_TYPE;
     private int mAdvertiseMode = DEFAULT_ADVERTISE_MODE;
     private int mAdvertiseTxPowerLevel = DEFAULT_ADVERTISE_TX_POWER_LEVEL;
     private int mScanMode = DEFAULT_SCAN_MODE;
@@ -348,6 +355,18 @@ public class DiscoveryManagerSettings extends AbstractSettings {
         }
     }
 
+    public AdvertisementDataType getAdvertisementDataType() {
+        return mAdvertisementDataType;
+    }
+
+    public void setAdvertisementDataType(AdvertisementDataType advertisementDataType) {
+        if (mAdvertisementDataType != advertisementDataType) {
+            mAdvertisementDataType = advertisementDataType;
+            mSharedPreferencesEditor.putInt(KEY_ADVERTISEMENT_DATA_TYPE, advertisementDataTypeToInt(mAdvertisementDataType));
+            mSharedPreferencesEditor.apply();
+        }
+    }
+
     /**
      * @return The Bluetooth LE advertise model.
      */
@@ -478,6 +497,9 @@ public class DiscoveryManagerSettings extends AbstractSettings {
             mDiscoveryMode = intToDiscoveryMode(discoveryModeAsInt);
             mPeerExpirationInMilliseconds = mSharedPreferences.getLong(
                     KEY_PEER_EXPIRATION, DEFAULT_PEER_EXPIRATION_IN_MILLISECONDS);
+            int advertisementDataTypeAsInt = mSharedPreferences.getInt(
+                    KEY_ADVERTISEMENT_DATA_TYPE, advertisementDataTypeToInt(DEFAULT_ADVERTISEMENT_DATA_TYPE));
+            mAdvertisementDataType = intToAdvertisementDataType(advertisementDataTypeAsInt);
             mAdvertiseMode = mSharedPreferences.getInt(KEY_ADVERTISE_MODE, DEFAULT_ADVERTISE_MODE);
             mAdvertiseTxPowerLevel = mSharedPreferences.getInt(
                     KEY_ADVERTISE_TX_POWER_LEVEL, DEFAULT_ADVERTISE_TX_POWER_LEVEL);
@@ -491,6 +513,7 @@ public class DiscoveryManagerSettings extends AbstractSettings {
                     + "\n    - Bluetooth MAC address: " + mBluetoothMacAddress
                     + "\n    - Discovery mode: " + mDiscoveryMode
                     + "\n    - Peer expiration time in milliseconds: " + mPeerExpirationInMilliseconds
+                    + "\n    - Advertisement data type: " + mAdvertisementDataType
                     + "\n    - Advertise mode: " + mAdvertiseMode
                     + "\n    - Advertise TX power level: " + mAdvertiseTxPowerLevel
                     + "\n    - Scan mode: " + mScanMode
@@ -548,6 +571,30 @@ public class DiscoveryManagerSettings extends AbstractSettings {
         }
 
         return DEFAULT_DISCOVERY_MODE;
+    }
+
+    private int advertisementDataTypeToInt(AdvertisementDataType advertisementDataType) {
+        switch (advertisementDataType) {
+            case SERVICE_DATA: return ADVERTISEMENT_DATA_TYPE_SERVICE;
+            case MANUFACTURER_DATA: return ADVERTISEMENT_DATA_TYPE_MANUFACTURER;
+            default:
+                Log.e(TAG, "advertisementDataTypeToInt: Unrecognized advertisement type: " + advertisementDataType);
+                break;
+        }
+
+        return ADVERTISEMENT_DATA_TYPE_SERVICE;
+    }
+
+    private AdvertisementDataType intToAdvertisementDataType(int advertisementDataTypeAsInt) {
+        switch (advertisementDataTypeAsInt) {
+            case ADVERTISEMENT_DATA_TYPE_SERVICE: return AdvertisementDataType.SERVICE_DATA;
+            case ADVERTISEMENT_DATA_TYPE_MANUFACTURER: return AdvertisementDataType.MANUFACTURER_DATA;
+            default:
+                Log.e(TAG, "intToAdvertisementDataType: Invalid argument: " + advertisementDataTypeAsInt);
+                break;
+        }
+
+        return AdvertisementDataType.SERVICE_DATA;
     }
 
     /**

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/AbstractBluetoothConnectivityAgent.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/AbstractBluetoothConnectivityAgent.java
@@ -157,6 +157,7 @@ public abstract class AbstractBluetoothConnectivityAgent implements BluetoothMan
 
         if (!CommonUtils.isNonEmptyString(mMyIdentityString)) {
             if (CommonUtils.isNonEmptyString(mMyPeerName)
+                    && !mMyPeerName.equals(PeerProperties.NO_PEER_NAME_STRING)
                     && BluetoothUtils.isValidBluetoothMacAddress(bluetoothMacAddress)) {
                 try {
                     mMyIdentityString = createIdentityString(mMyPeerName, bluetoothMacAddress);

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/AbstractBluetoothThread.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/AbstractBluetoothThread.java
@@ -4,6 +4,7 @@
 package org.thaliproject.p2p.btconnectorlib.internal.bluetooth;
 
 import org.thaliproject.p2p.btconnectorlib.utils.CommonUtils;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 /**
@@ -48,6 +49,7 @@ abstract class AbstractBluetoothThread extends Thread {
      */
     protected byte[] getHandshakeMessage() {
         return (CommonUtils.isNonEmptyString(mMyIdentityString)
-                ? mMyIdentityString.getBytes() : CommonUtils.createSimpleHandshakeMessage());
+                ? mMyIdentityString.getBytes(StandardCharsets.UTF_8)
+                : BluetoothUtils.SIMPLE_HANDSHAKE_MESSAGE_AS_BYTE_ARRAY);
     }
 }

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothClientThread.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothClientThread.java
@@ -219,7 +219,7 @@ class BluetoothClientThread extends AbstractBluetoothThread implements Bluetooth
         Log.d(TAG, "onBytesRead: Read " + size + " bytes successfully (thread ID: " + threadId + ")");
 
         PeerProperties peerProperties =
-                BluetoothUtils.validateReceivedHandshakeMessage(bytes, bluetoothSocket);
+                BluetoothUtils.validateReceivedHandshakeMessage(bytes, size, bluetoothSocket);
 
         if (peerProperties != null) {
             Log.i(TAG, "Handshake succeeded with " + peerProperties.toString());

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothClientThread.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothClientThread.java
@@ -197,7 +197,7 @@ class BluetoothClientThread extends AbstractBluetoothThread implements Bluetooth
      */
     @Override
     public synchronized void shutdown() {
-        Log.d(TAG, "shutdown (thread ID: " + getId() + ")");
+        Log.d(TAG, "shutdown: Thread ID: " + getId());
         mIsShuttingDown = true;
         mListener = null;
         close();
@@ -297,9 +297,11 @@ class BluetoothClientThread extends AbstractBluetoothThread implements Bluetooth
 
         if (mBluetoothSocket != null) {
             try {
+                Log.d(TAG, "close: Trying to close the Bluetooth socket... (thread ID: " + getId() + ")");
                 mBluetoothSocket.close();
+                Log.d(TAG, "close: Bluetooth socket closed (thread ID: " + getId() + ")");
             } catch (IOException e) {
-                Log.w(TAG, "Failed to close the socket: " + e.getMessage());
+                Log.w(TAG, "close: Failed to close the socket (thread ID: " + getId() + "): " + e.getMessage());
             }
 
             mBluetoothSocket = null;

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothConnector.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothConnector.java
@@ -393,7 +393,7 @@ public class BluetoothConnector
             }
 
             if (bluetoothClientThread != null) {
-                isCancelling = shutdownAndRemoveClientThread(bluetoothClientThread);
+                isCancelling = removeAndShutdownBluetoothClientThread(bluetoothClientThread);
             }
         } else {
             if (peerProperties == null) {
@@ -559,7 +559,7 @@ public class BluetoothConnector
             }
         });
 
-        shutdownAndRemoveClientThread(who);
+        removeAndShutdownBluetoothClientThread(who);
     }
 
     /**
@@ -638,12 +638,7 @@ public class BluetoothConnector
                                     + bluetoothClientThread.getId() + ")");
                         }
 
-                        new Thread() {
-                            @Override
-                            public void run() {
-                                bluetoothClientThread.shutdown(); // Try to cancel
-                            }
-                        }.start();
+                        shutdownBluetoothClientThread(bluetoothClientThread); // Try to cancel
 
                         mHandler.post(new Runnable() {
                             @Override
@@ -674,32 +669,25 @@ public class BluetoothConnector
      * @param bluetoothClientThread The Bluetooth client thread instance to shut down and remove.
      * @return True, if the thread was shut down and removed. False otherwise.
      */
-    private synchronized boolean shutdownAndRemoveClientThread(final BluetoothClientThread bluetoothClientThread) {
-        boolean wasShutdownAndRemoved = false;
+    private synchronized boolean removeAndShutdownBluetoothClientThread(final BluetoothClientThread bluetoothClientThread) {
+        boolean wasRemovedAndShutdown = false;
 
         if (bluetoothClientThread != null) {
             if (mClientThreads.size() > 0) {
                 for (BluetoothClientThread currentBluetoothClientThread : mClientThreads) {
                     if (currentBluetoothClientThread != null
                             && currentBluetoothClientThread.getId() == bluetoothClientThread.getId()) {
-                        Log.i(TAG, "shutdownAndRemoveClientThread: Shutting down thread with ID "
-                                + bluetoothClientThread.getId());
+                        Log.i(TAG, "removeAndShutdownBluetoothClientThread: Thread ID: " + bluetoothClientThread.getId());
 
                         mClientThreads.remove(currentBluetoothClientThread);
-
-                        new Thread() {
-                            @Override
-                            public void run() {
-                                bluetoothClientThread.shutdown();
-                            }
-                        }.start();
+                        shutdownBluetoothClientThread(currentBluetoothClientThread);
 
                         if (mConnectionTimeoutTimer != null && mClientThreads.size() == 0) {
                             mConnectionTimeoutTimer.cancel();
                             mConnectionTimeoutTimer = null;
                         }
 
-                        wasShutdownAndRemoved = true;
+                        wasRemovedAndShutdown = true;
                         break;
                     }
                 }
@@ -708,10 +696,28 @@ public class BluetoothConnector
             throw new NullPointerException("The given Bluetooth client thread instance is null");
         }
 
-        if (!wasShutdownAndRemoved) {
-            Log.w(TAG, "shutdownAndRemoveClientThread: Failed to find a thread with ID " + bluetoothClientThread.getId());
+        if (!wasRemovedAndShutdown) {
+            Log.w(TAG, "removeAndShutdownBluetoothClientThread: Failed to find a thread with ID " + bluetoothClientThread.getId());
         }
 
-        return wasShutdownAndRemoved;
+        return wasRemovedAndShutdown;
+    }
+
+    /**
+     * Tries to shutdown the given Bluetooth client thread.
+     *
+     * @param bluetoothClientThread The Bluetooth client thread to shutdown.
+     */
+    private synchronized void shutdownBluetoothClientThread(final BluetoothClientThread bluetoothClientThread) {
+        if (bluetoothClientThread != null) {
+            Log.d(TAG, "shutdownBluetoothClientThread: Thread ID: " + bluetoothClientThread.getId());
+
+            new Thread() {
+                @Override
+                public void run() {
+                    bluetoothClientThread.shutdown();
+                }
+            }.start();
+        }
     }
 }

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothConnector.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothConnector.java
@@ -113,6 +113,8 @@ public class BluetoothConnector
             throw new NullPointerException("Listener, Bluetooth adapter instance or service record UUID is null");
         }
 
+        Log.d(TAG, "BluetoothConnector: Bluetooth name: " + myBluetoothName + ", service record UUID: " + serviceRecordUuid.toString());
+
         mListener = listener;
         mBluetoothAdapter = bluetoothAdapter;
         mServiceRecordUuid = serviceRecordUuid;

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothManager.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothManager.java
@@ -111,7 +111,7 @@ public class BluetoothManager {
      */
     public synchronized void release(BluetoothManagerListener listener) {
         if (!mListeners.remove(listener) && mListeners.size() > 0) {
-            Log.e(TAG, "release: The given listener does not exist in the list - probably already removed");
+            Log.w(TAG, "release: The given listener does not exist in the list - probably already removed");
         }
 
         if (mListeners.size() == 0) {

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothServerThread.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothServerThread.java
@@ -169,16 +169,9 @@ class BluetoothServerThread extends AbstractBluetoothThread implements Bluetooth
                     mListener.onIncomingConnectionFailed("Socket is null");
                     mStopThread = true;
                 }
-
-                try {
-                    mBluetoothServerSocket.close();
-                    Log.v(TAG, "Bluetooth server socket closed");
-                } catch (IOException | NullPointerException e) {
-                    Log.e(TAG, "Failed to close the Bluetooth server socket: " + e.getMessage(), e);
-                }
-
-                mBluetoothServerSocket = null;
             } // if (mBluetoothServerSocket != null && !mStopThread)
+
+            closeBluetoothServerSocket();
         } // while (!mStopThread)
 
         Log.d(TAG, "Exiting thread");
@@ -197,6 +190,7 @@ class BluetoothServerThread extends AbstractBluetoothThread implements Bluetooth
     public synchronized void shutdown() {
         Log.d(TAG, "shutdown");
         mStopThread = true;
+        closeBluetoothServerSocket();
 
         for (BluetoothSocketIoThread thread : mSocketIoThreads) {
             if (thread != null) {
@@ -205,14 +199,6 @@ class BluetoothServerThread extends AbstractBluetoothThread implements Bluetooth
         }
 
         mSocketIoThreads.clear();
-
-        if (mBluetoothServerSocket != null) {
-            try {
-                mBluetoothServerSocket.close();
-            } catch (IOException | NullPointerException e) {
-                Log.e(TAG, "Failed to close the Bluetooth server socket: " + e.getMessage(), e);
-            }
-        }
     }
 
     /**
@@ -289,6 +275,25 @@ class BluetoothServerThread extends AbstractBluetoothThread implements Bluetooth
 
         if (threadFound) {
             Log.e(TAG, "Handshake failed (thread ID: " + threadId + ")");
+        }
+    }
+
+    /**
+     * Closes the Bluetooth server socket.
+     */
+    private synchronized void closeBluetoothServerSocket() {
+        final BluetoothServerSocket bluetoothServerSocket = mBluetoothServerSocket;
+        mBluetoothServerSocket = null;
+
+        if (bluetoothServerSocket != null) {
+            try {
+                bluetoothServerSocket.close();
+                Log.v(TAG, "closeBluetoothServerSocket: Bluetooth server socket closed");
+            } catch (IOException | NullPointerException e) {
+                Log.e(TAG, "closeBluetoothServerSocket: Failed to close the Bluetooth server socket: " + e.getMessage(), e);
+            }
+        } else {
+            Log.v(TAG, "closeBluetoothServerSocket: No Bluetooth server socket to close");
         }
     }
 

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothServerThread.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothServerThread.java
@@ -229,7 +229,7 @@ class BluetoothServerThread extends AbstractBluetoothThread implements Bluetooth
         Log.d(TAG, "onBytesRead: Read " + size + " bytes successfully (thread ID: " + threadId + ")");
 
         PeerProperties peerProperties =
-                BluetoothUtils.validateReceivedHandshakeMessage(bytes, who.getSocket());
+                BluetoothUtils.validateReceivedHandshakeMessage(bytes, size, who.getSocket());
 
         if (peerProperties != null) {
             Log.i(TAG, "Got valid identity from " + peerProperties.toString());

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BleAdvertiser.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BleAdvertiser.java
@@ -20,12 +20,14 @@ class BleAdvertiser extends AdvertiseCallback {
     public interface Listener {
         /**
          * Called when the Bluetooth LE advertiser fails to start.
+         *
          * @param errorCode The error code.
          */
         void onAdvertiserFailedToStart(int errorCode);
 
         /**
          * Called when this advertiser is started or stopped.
+         *
          * @param isStarted If true, the advertising was started. If false, the advertising was stopped.
          */
         void onIsAdvertiserStartedChanged(boolean isStarted);
@@ -46,6 +48,7 @@ class BleAdvertiser extends AdvertiseCallback {
 
     /**
      * Constructor.
+     *
      * @param listener The listener.
      * @param bluetoothAdapter The Bluetooth adapter.
      */
@@ -77,6 +80,7 @@ class BleAdvertiser extends AdvertiseCallback {
 
     /**
      * Sets the advertise data. Restarts the instance, if it was started/running.
+     *
      * @param advertiseData The advertise data to set.
      */
     public void setAdvertiseData(AdvertiseData advertiseData) {
@@ -100,6 +104,7 @@ class BleAdvertiser extends AdvertiseCallback {
 
     /**
      * Sets the advertise settings. Note that the advertiser is not restarted automatically.
+     *
      * @param advertiseSettings The advertise settings to set.
      */
     public void setAdvertiseSettings(AdvertiseSettings advertiseSettings) {
@@ -124,6 +129,7 @@ class BleAdvertiser extends AdvertiseCallback {
 
     /**
      * Tries to start advertising.
+     *
      * @return True, if starting. False in case of a failure.
      */
     public synchronized boolean start() {
@@ -152,6 +158,7 @@ class BleAdvertiser extends AdvertiseCallback {
 
     /**
      * Stops advertising.
+     *
      * @param notifyStateChanged If true, will notify the listener, if the state is changed.
      */
     public synchronized void stop(boolean notifyStateChanged) {
@@ -169,6 +176,7 @@ class BleAdvertiser extends AdvertiseCallback {
 
     /**
      * Notifies the listener.
+     *
      * @param errorCode The error code.
      */
     @Override
@@ -212,6 +220,7 @@ class BleAdvertiser extends AdvertiseCallback {
 
     /**
      * Sets the state and notifies listener if required.
+     *
      * @param state The new state.
      * @param notifyStateChanged If true, will notify the listener, if the state is changed.
      */

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BleAdvertiser.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BleAdvertiser.java
@@ -131,6 +131,7 @@ class BleAdvertiser extends AdvertiseCallback {
             if (mBluetoothLeAdvertiser != null) {
                 if (mAdvertiseData != null) {
                     try {
+                        Log.v(TAG, "start: Starting...");
                         mBluetoothLeAdvertiser.startAdvertising(mAdvertiseSettings, mAdvertiseData, null, this);
                         setState(State.STARTING, true);
                     } catch (Exception e) {

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BlePeerDiscoverer.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BlePeerDiscoverer.java
@@ -5,6 +5,7 @@ package org.thaliproject.p2p.btconnectorlib.internal.bluetooth.le;
 
 import android.annotation.TargetApi;
 import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.le.AdvertiseCallback;
 import android.bluetooth.le.AdvertiseData;
 import android.bluetooth.le.AdvertiseSettings;
 import android.bluetooth.le.ScanFilter;
@@ -13,6 +14,7 @@ import android.bluetooth.le.ScanSettings;
 import android.os.CountDownTimer;
 import android.os.ParcelUuid;
 import android.util.Log;
+import org.thaliproject.p2p.btconnectorlib.DiscoveryManagerSettings;
 import org.thaliproject.p2p.btconnectorlib.PeerProperties;
 import org.thaliproject.p2p.btconnectorlib.internal.bluetooth.BluetoothUtils;
 import org.thaliproject.p2p.btconnectorlib.utils.CommonUtils;
@@ -99,9 +101,23 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
         ADVERTISING_PROVIDING_ASSISTANCE // Bro Mode - When helping a peer with its Bluetooth MAC address
     }
 
+    /**
+     * The type of the advertisement data advertised by the Bluetooth LE advertiser.
+     *
+     * MANUFACTURER_DATA: Will advertise using manufacturer data and will parse only manufacturer
+     *                    data based advertisements.
+     *
+     * SERVICE_DATA: Will advertise using service data and will scan (using a filter) and parse only
+     *               service data based advertisements.
+     *
+     * DO_NOT_CARE: Will advertise primarily using service data, but in case that fails, will
+     *              fallback to using manufacturer data. Will parse both manufacturer and service
+     *              data based advertisements.
+     */
     public enum AdvertisementDataType {
         MANUFACTURER_DATA,
-        SERVICE_DATA
+        SERVICE_DATA,
+        DO_NOT_CARE
     }
 
     protected enum AdvertisementType {
@@ -118,7 +134,7 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
     private final BluetoothAdapter mBluetoothAdapter;
     private final UUID mServiceUuid;
     private final UUID mProvideBluetoothMacAddressRequestUuid;
-    private final AdvertisementDataType mAdvertisementDataType;
+    private AdvertisementDataType mAdvertisementDataType = DiscoveryManagerSettings.DEFAULT_ADVERTISEMENT_DATA_TYPE;
     private String mMyBluetoothMacAddress = null;
     private EnumSet<BlePeerDiscovererStateSet> mStateSet = EnumSet.of(BlePeerDiscovererStateSet.NOT_STARTED);
     private final BleAdvertiser mBleAdvertiser;
@@ -127,6 +143,7 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
     private CountDownTimer mPeerAddressHelperAdvertisementTimeoutTimer = null;
     private boolean mIsAssistingPeer = false;
     private boolean mWasAdvertiserStartedBeforeStartingToAssistPeer = false;
+    private boolean mAdvertiserFailedToStartUsingServiceData = false;
 
     /**
      * See PeerAdvertisementFactory.generateNewProvideBluetoothMacAddressRequestUuid
@@ -139,11 +156,13 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
 
     /**
      * Constructor.
+     *
      * @param listener The listener.
      * @param bluetoothAdapter The Bluetooth adapter.
      * @param serviceUuid The BLE service UUID.
      * @param provideBluetoothMacAddressRequestUuid UUID for "Provide Bluetooth MAC address" mode.
      * @param myBluetoothMacAddress Our Bluetooth MAC address for advertisement.
+     * @param advertisementDataType The advertisement data type.
      */
     public BlePeerDiscoverer(
             BlePeerDiscoveryListener listener, BluetoothAdapter bluetoothAdapter,
@@ -159,7 +178,6 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
         mServiceUuid = serviceUuid;
         mProvideBluetoothMacAddressRequestUuid = provideBluetoothMacAddressRequestUuid;
         mMyBluetoothMacAddress = myBluetoothMacAddress;
-        mAdvertisementDataType = advertisementDataType;
 
         mBleAdvertiser = new BleAdvertiser(this, mBluetoothAdapter);
 
@@ -171,15 +189,8 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
         }
 
         mBleScanner = new BleScanner(this, mBluetoothAdapter);
-        ScanFilter scanFilter = null;
 
-        //if (mAdvertisementDataType == AdvertisementDataType.SERVICE_DATA) {
-        //    scanFilter = BlePeerDiscoveryUtils.createScanFilter(mServiceUuid, false);
-        //} else {
-            scanFilter = BlePeerDiscoveryUtils.createScanFilter(null, true);
-        //}
-
-        mBleScanner.addFilter(scanFilter);
+        mAdvertisementDataType = advertisementDataType;
     }
 
     /**
@@ -208,6 +219,7 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
 
     /**
      * Sets the Bluetooth MAC address. Note that the advertiser is not restarted automatically.
+     *
      * @param myBluetoothMacAddress Our Bluetooth MAC address.
      */
     public void setBluetoothMacAddress(String myBluetoothMacAddress) {
@@ -222,6 +234,8 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
 
     /**
      * Sets the settings for both the BLE advertiser and the scanner.
+     *
+     * @param advertisementDataType The advertisement data type.
      * @param advertiseMode The advertise mode for the BLE advertiser.
      * @param advertiseTxPowerLevel The advertise TX power level for the BLE advertiser.
      * @param scanMode The scan mode for the BLE scanner.
@@ -229,12 +243,24 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
      * @return True, if all the settings were applied successfully. False, if at least one of
      * settings failed to be applied.
      */
-    public boolean applySettings(int advertiseMode, int advertiseTxPowerLevel, int scanMode, long scanReportDelayInMilliseconds) {
-        Log.i(TAG, "applySettings: Advertise mode: " + advertiseMode
-                + ", advertise TX power level: " + advertiseTxPowerLevel
-                + ", scan mode: " + scanMode);
+    public boolean applySettings(
+            AdvertisementDataType advertisementDataType, int advertiseMode, int advertiseTxPowerLevel,
+            int scanMode, long scanReportDelayInMilliseconds) {
+        Log.i(TAG, "applySettings:"
+                + "\n    - Advertisement data type: " + advertisementDataType
+                + "\n    - Advertise mode: " + advertiseMode
+                + "\n    - Advertise TX power level: " + advertiseTxPowerLevel
+                + "\n    - Scan mode: " + scanMode
+                + "\n    - Scan report delay in milliseconds: " + scanReportDelayInMilliseconds);
 
         boolean advertiserSettingsWereSet = false;
+
+        if (mAdvertisementDataType != advertisementDataType) {
+            mAdvertisementDataType = advertisementDataType;
+            // The advertise data will be automatically updated when the advertiser is started/restarted
+            // The scanner filter will be automatically updated when the scanner is started/restarted
+        }
+
         AdvertiseSettings.Builder advertiseSettingsBuilder = new AdvertiseSettings.Builder();
 
         try {
@@ -263,7 +289,7 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
             mBleAdvertiser.setAdvertiseSettings(advertiseSettingsBuilder.build());
 
             if (advertiserWasStarted) {
-                mBleAdvertiser.start();
+                startAdvertiser();
             }
         }
 
@@ -293,7 +319,7 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
             mBleScanner.setScanSettings(scanSettingsBuilder.build());
 
             if (scannerWasStarted) {
-                mBleScanner.start();
+                startScanner();
             }
         }
 
@@ -301,12 +327,17 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
     }
 
     /**
-     * Starts the BLE scanner.
+     * Starts the BLE scanner. Adds the appropriate filter for the scanner, if the scanner was not
+     * already running.
+     *
      * @return True, if starting or already started. False otherwise.
      */
     public synchronized boolean startScanner() {
         if (!mBleScanner.isStarted()) {
             Log.i(TAG, "startScanner: Starting...");
+
+            mBleScanner.clearScanFilters();
+            mBleScanner.addScanFilter(createScanFilter());
         }
 
         return mBleScanner.start();
@@ -325,6 +356,7 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
 
     /**
      * Starts the BLE advertiser.
+     *
      * @return True, if starting or already started. False otherwise.
      */
     public synchronized boolean startAdvertiser() {
@@ -475,10 +507,30 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
         }
     }
 
+    /**
+     * Called when the Bluetooth LE advertiser fails to start.
+     *
+     * If the error code was ADVERTISE_FAILED_DATA_TOO_LARGE and the advertisement data type is
+     * DO_NOT_CARE and this is the first time we got the error (using service data), we will try
+     * fallback to using manufacturer data instead.
+     *
+     * @param errorCode The error code.
+     */
     @Override
     public void onAdvertiserFailedToStart(int errorCode) {
         Log.e(TAG, "onAdvertiserFailedToStart: " + errorCode);
         // No need to update state here, since onIsAdvertiserStartedChanged will be called
+
+        if (errorCode == AdvertiseCallback.ADVERTISE_FAILED_DATA_TOO_LARGE
+                && mAdvertisementDataType == AdvertisementDataType.DO_NOT_CARE) {
+            if (!mAdvertiserFailedToStartUsingServiceData) {
+                Log.i(TAG, "onAdvertiserFailedToStart: Falling back to using manufacturer data - restarting...");
+                mAdvertiserFailedToStartUsingServiceData = true;
+                startAdvertiser();
+            } else {
+                Log.e(TAG, "onAdvertiserFailedToStart: Manufacturer data fallback did not work either");
+            }
+        }
     }
 
     @Override
@@ -506,35 +558,46 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
 
     /**
      * Tries to parse the given result and take action based on the advertisement type.
+     *
      * @param scanResult The scan result.
      */
     private synchronized void checkScanResult(ScanResult scanResult) {
         BlePeerDiscoveryUtils.ParsedAdvertisement parsedAdvertisement = null;
 
         if (scanResult != null && scanResult.getScanRecord() != null) {
-            // Try service data first
-            Map<ParcelUuid, byte[]> serviceData = scanResult.getScanRecord().getServiceData();
+            if (mAdvertisementDataType == AdvertisementDataType.SERVICE_DATA
+                    || mAdvertisementDataType == AdvertisementDataType.DO_NOT_CARE) {
+                // Try to parse the service data
+                Map<ParcelUuid, byte[]> serviceData = scanResult.getScanRecord().getServiceData();
 
-            if (serviceData != null && serviceData.size() > 0) {
-                for (ParcelUuid uuid : serviceData.keySet()) {
-                    byte[] serviceDataContent = serviceData.get(uuid);
-                    //Log.v(TAG, "checkScanResult: Got service data with UUID \"" + uuid + "\"");
-                    parsedAdvertisement = BlePeerDiscoveryUtils.parseServiceData(serviceDataContent);
+                if (serviceData != null && serviceData.size() > 0) {
+                    for (ParcelUuid uuid : serviceData.keySet()) {
+                        byte[] serviceDataContent = serviceData.get(uuid);
+                        //Log.v(TAG, "checkScanResult: Got service data with UUID \"" + uuid + "\"");
+                        parsedAdvertisement = BlePeerDiscoveryUtils.parseServiceData(serviceDataContent);
 
-                    if (parsedAdvertisement != null) {
-                        parsedAdvertisement.uuid = scanResult.getScanRecord().getServiceUuids().get(0).getUuid();
-                        parsedAdvertisement.provideBluetoothMacAddressRequestId =
-                                BlePeerDiscoveryUtils.checkIfUuidContainsProvideBluetoothMacAddressRequestId(
-                                        parsedAdvertisement.uuid, mServiceUuid);
-                        break;
+                        if (parsedAdvertisement != null) {
+                            UUID scannedServiceUuid = scanResult.getScanRecord().getServiceUuids().get(0).getUuid();
+
+                            if (mAdvertisementDataType == AdvertisementDataType.SERVICE_DATA
+                                    || BlePeerDiscoveryUtils.uuidStartsWithExpectedServiceUuid(scannedServiceUuid, mServiceUuid)) {
+                                parsedAdvertisement.uuid = scanResult.getScanRecord().getServiceUuids().get(0).getUuid();
+                                parsedAdvertisement.provideBluetoothMacAddressRequestId =
+                                        BlePeerDiscoveryUtils.checkIfUuidContainsProvideBluetoothMacAddressRequestId(
+                                                parsedAdvertisement.uuid, mServiceUuid);
+                                break;
+                            } else {
+                                // UUID mismatch
+                                parsedAdvertisement = null;
+                            }
+                        }
                     }
                 }
             }
 
-            if (parsedAdvertisement == null) {
-                // Check for manufacturer data
-                Log.v(TAG, "checkScanResult: Failed to parse the service data, trying manufacturer data");
-
+            if (mAdvertisementDataType == AdvertisementDataType.MANUFACTURER_DATA
+                    || (mAdvertisementDataType == AdvertisementDataType.DO_NOT_CARE && parsedAdvertisement == null)) {
+                // Try to parse the manufacturer data
                 byte[] manufacturerData = scanResult.getScanRecord().getManufacturerSpecificData(
                         PeerAdvertisementFactory.MANUFACTURER_ID);
 
@@ -620,6 +683,7 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
 
     /**
      * Creates the advertise data based on the current advertise data type and the given properties.
+     *
      * @param uuid The UUID.
      * @param bluetoothMacAddress The Bluetooth MAC address.
      * @return A newly created AdvertiseData instance.
@@ -627,9 +691,11 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
     private AdvertiseData createAdvertiseData(UUID uuid, String bluetoothMacAddress) {
         AdvertiseData advertiseData = null;
 
-        if (mAdvertisementDataType == AdvertisementDataType.SERVICE_DATA) {
+        if (mAdvertisementDataType == AdvertisementDataType.SERVICE_DATA
+                ||(mAdvertisementDataType == AdvertisementDataType.DO_NOT_CARE && !mAdvertiserFailedToStartUsingServiceData)) {
             advertiseData = PeerAdvertisementFactory.createAdvertiseDataToServiceData(uuid, bluetoothMacAddress);
         } else {
+            // MANUFACTURER_DATA or DO_NOT_CARE with failure trying to use service data
             advertiseData = PeerAdvertisementFactory.createAdvertiseDataToManufacturerData(uuid, bluetoothMacAddress);
         }
 
@@ -637,7 +703,26 @@ public class BlePeerDiscoverer implements BleAdvertiser.Listener, BleScanner.Lis
     }
 
     /**
+     * Creates the scan filter based on the set advertisement data type.
+     *
+     * @return A newly created scan filter.
+     */
+    private ScanFilter createScanFilter() {
+        ScanFilter scanFilter = null;
+
+        if (mAdvertisementDataType == AdvertisementDataType.SERVICE_DATA) {
+            scanFilter = BlePeerDiscoveryUtils.createScanFilter(mServiceUuid, false);
+        } else {
+            // Either MANUFACTURER_DATA or DO_NOT_CARE
+            scanFilter = BlePeerDiscoveryUtils.createScanFilter(null, true);
+        }
+
+        return scanFilter;
+    }
+
+    /**
      * Resolves the type of the parsed advertisement.
+     *
      * @param parsedAdvertisement The parsed advertisement.
      * @return The advertisement type. Will return AdvertisementType.ADVERTISEMENT_UNKNOWN, if the
      * type is not recognized (and should be ignored).

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BlePeerDiscoveryUtils.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BlePeerDiscoveryUtils.java
@@ -170,10 +170,6 @@ class BlePeerDiscoveryUtils {
             } catch (IndexOutOfBoundsException e) {
                 Log.e(TAG, "parseManufacturerData: Failed to parse data: " + e.getMessage(), e);
             }
-        } else {
-            Log.e(TAG, "parseManufacturerData: " + ((manufacturerData != null)
-                    ? ("Manufacturer data length is too short (" + manufacturerData.length + ") - the minimum length is " + ADVERTISEMENT_BYTE_COUNT)
-                    : "Manufacturer data is null"));
         }
 
         ParsedAdvertisement parsedAdvertisement = null;

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BlePeerDiscoveryUtils.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BlePeerDiscoveryUtils.java
@@ -43,6 +43,7 @@ class BlePeerDiscoveryUtils {
 
     /**
      * Creates a new scan filter based on the given arguments.
+     *
      * @param serviceUuid The service UUID for the scan filter. Use null to not set.
      * @param useManufacturerId If true, will add the manufacturer ID to the filter properties.
      * @return A newly created scan filter or null in case of a failure.
@@ -76,6 +77,7 @@ class BlePeerDiscoveryUtils {
 
     /**
      * Parses the given service data.
+     *
      * @param serviceData The service data. Expected contain a "0" byte followed by the six bytes
      *                    consisting of the Bluetooth MAC address.
      * @return A newly created ParsedAdvertisement instance, containing at least the Bluetooth MAC
@@ -104,7 +106,33 @@ class BlePeerDiscoveryUtils {
     }
 
     /**
+     * Checks if the given UUID starts with the given service UUID i.e. their beginnings match.
+     *
+     * @param uuidToCheck The UUID to check.
+     * @param serviceUuid The expected service UUID to compare against.
+     * @return True, if the beginnings match. False otherwise.
+     */
+    public static boolean uuidStartsWithExpectedServiceUuid(UUID uuidToCheck, UUID serviceUuid) {
+        boolean startsWithExpectedServiceUuid = false;
+
+        if (uuidToCheck != null && serviceUuid != null) {
+            if (serviceUuid.compareTo(uuidToCheck) == 0) {
+                // The UUID is a match
+                // No need to do anything
+                startsWithExpectedServiceUuid = true;
+            } else {
+                // Get the beginning of the parsed UUID, leave out the last seven bytes (11 chars)
+                String beginningOfUuidToCheck = uuidToCheck.toString().substring(0, 22);
+                startsWithExpectedServiceUuid = serviceUuid.toString().startsWith(beginningOfUuidToCheck);
+            }
+        }
+
+        return startsWithExpectedServiceUuid;
+    }
+
+    /**
      * Checks the given UUID for "Provide Bluetooth MAC address" request ID.
+     *
      * @param uuidToCheck The UUID to check.
      * @param serviceUuid The expected service UUID to compare against.
      * @return The request ID or null if not found.
@@ -136,6 +164,7 @@ class BlePeerDiscoveryUtils {
 
     /**
      * Parses the given manufacturer data.
+     *
      * @param manufacturerData The manufacturer data.
      * @return A newly created ParsedAdvertisement instance containing at least the UUID given that
      * the manufacturer data is valid. Note that other members of the instance can be null. Will
@@ -196,6 +225,7 @@ class BlePeerDiscoveryUtils {
 
     /**
      * Parses the given manufacturer data.
+     *
      * @param manufacturerData The manufacturer data.
      * @param serviceUuid The expected service UUID.
      * @return A newly created ParsedAdvertisement instance or null in case of UUID mismatch.
@@ -207,8 +237,13 @@ class BlePeerDiscoveryUtils {
             parsedAdvertisement = parseManufacturerData(manufacturerData);
 
             if (parsedAdvertisement != null) {
-                parsedAdvertisement.provideBluetoothMacAddressRequestId =
-                        checkIfUuidContainsProvideBluetoothMacAddressRequestId(parsedAdvertisement.uuid, serviceUuid);
+                if (uuidStartsWithExpectedServiceUuid(parsedAdvertisement.uuid, serviceUuid)) {
+                    parsedAdvertisement.provideBluetoothMacAddressRequestId =
+                            checkIfUuidContainsProvideBluetoothMacAddressRequestId(parsedAdvertisement.uuid, serviceUuid);
+                } else {
+                    // The beginning of the UUID does not match the given service UUID
+                    parsedAdvertisement = null;
+                }
             }
         }
 
@@ -217,6 +252,7 @@ class BlePeerDiscoveryUtils {
 
     /**
      * Converts the given UUID into a byte array.
+     *
      * @param uuid The UUID to convert.
      * @return A newly created byte array or null in case of a failure.
      */
@@ -241,6 +277,7 @@ class BlePeerDiscoveryUtils {
 
     /**
      * Converts the given byte array, which is expected to contain the UUID, into a UUID instance.
+     *
      * @param byteArray The byte array containing the UUID.
      * @return A newly created UUID instance or null in case of a failure.
      */
@@ -258,6 +295,7 @@ class BlePeerDiscoveryUtils {
 
     /**
      * Converts the given Bluetooth MAC address into a byte array.
+     *
      * @param bluetoothMacAddress The Bluetooth MAC address to convert.
      * @return A newly created byte array containing the Bluetooth MAC address or null in case of a failure.
      */
@@ -292,6 +330,7 @@ class BlePeerDiscoveryUtils {
 
     /**
      * Converts the given byte array, which should contain the Bluetooth MAC address, into a string.
+     *
      * @param byteArray The byte array containing the Bluetooth MAC address.
      * @return A newly created string containing the Bluetooth MAC address or null in case of a failure.
      */
@@ -393,6 +432,7 @@ class BlePeerDiscoveryUtils {
     /**
      * Checks if the two UUIDs match, if we leave out the request ID part from the end
      * (6 bytes, 12 characters).
+     *
      * @param uuid1 UUID 1.
      * @param uuid2 UUID 2.
      * @return True, if the UUIDs match. False otherwise.
@@ -414,6 +454,7 @@ class BlePeerDiscoveryUtils {
 
     /**
      * Generates a random byte and returns it as a hexadecimal string.
+     *
      * @return A random byte as hexadecimal string.
      */
     public static String generatedRandomByteAsHexString() {
@@ -428,6 +469,7 @@ class BlePeerDiscoveryUtils {
     /**
      * Converts the given Bluetooth address into an integer array.
      * Since Java does not have unsigned bytes we have to use signed 8 bit integers.
+     *
      * @param bluetoothAddress The Bluetooth address to convert.
      * @return An integer array containing the Bluetooth address.
      */
@@ -458,6 +500,7 @@ class BlePeerDiscoveryUtils {
     /**
      * Tries to parse a Bluetooth address from the given integer array.
      * Since Java does not have unsigned bytes we have to use signed 8 bit integers.
+     *
      * @param bluetoothAddressAsInt8Array The integer array containing the Bluetooth address.
      * @return The parsed Bluetooth address.
      */

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BlePeerDiscoveryUtils.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BlePeerDiscoveryUtils.java
@@ -8,8 +8,6 @@ import android.bluetooth.le.ScanFilter;
 import android.os.ParcelUuid;
 import android.util.Log;
 import org.thaliproject.p2p.btconnectorlib.internal.bluetooth.BluetoothUtils;
-import org.thaliproject.p2p.btconnectorlib.utils.CommonUtils;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BleScanner.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/le/BleScanner.java
@@ -55,6 +55,7 @@ class BleScanner extends ScanCallback {
 
     /**
      * Constructor.
+     *
      * @param listener The listener.
      * @param bluetoothAdapter The Bluetooth adapter.
      */
@@ -94,6 +95,7 @@ class BleScanner extends ScanCallback {
 
     /**
      * Tries to start the BLE scanning.
+     *
      * @return True, if starting. False in case of an error.
      */
     public synchronized boolean start() {
@@ -117,6 +119,7 @@ class BleScanner extends ScanCallback {
 
     /**
      * Stops the scanning.
+     *
      * @param notifyStateChanged If true, will notify the listener, if the state is changed.
      */
     public synchronized void stop(boolean notifyStateChanged) {
@@ -151,9 +154,10 @@ class BleScanner extends ScanCallback {
 
     /**
      * Adds the given scan filter to the list of filters. If the scanning is running, it is restarted.
+     *
      * @param scanFilter The scan filter to add.
      */
-    public void addFilter(ScanFilter scanFilter) {
+    public void addScanFilter(ScanFilter scanFilter) {
         if (scanFilter != null) {
             boolean wasStarted = (mState != State.NOT_STARTED);
 
@@ -171,6 +175,7 @@ class BleScanner extends ScanCallback {
 
     /**
      * Sets the scan settings. If not set explicitly, default settings will be used.
+     *
      * @param scanSettings The new scan settings.
      */
     public void setScanSettings(ScanSettings scanSettings) {
@@ -263,6 +268,7 @@ class BleScanner extends ScanCallback {
 
     /**
      * Sets the state and notifies listener if required.
+     *
      * @param state The new state.
      * @param notifyStateChanged If true, will notify the listener, if the state is changed.
      */

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/wifi/WifiDirectManager.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/wifi/WifiDirectManager.java
@@ -90,7 +90,7 @@ public class WifiDirectManager {
      */
     public synchronized void release(WifiStateListener listener) {
         if (!mListeners.remove(listener) && mListeners.size() > 0) {
-            Log.e(TAG, "release: The given listener does not exist in the list - probably already removed");
+            Log.w(TAG, "release: The given listener does not exist in the list - probably already removed");
         }
 
         if (mListeners.size() == 0) {

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/utils/CommonUtils.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/utils/CommonUtils.java
@@ -76,17 +76,6 @@ public class CommonUtils {
     }
 
     /**
-     * Creates a simple handshake message.
-     *
-     * @return The newly created handshake message as a byte array.
-     */
-    public static byte[] createSimpleHandshakeMessage() {
-        byte[] message = new byte[1];
-        message[0] = (byte) 0x0;
-        return message;
-    }
-
-    /**
      * Converts the content of the given byte array to hex string.
      *
      * @param bytes The bytes to convert.

--- a/BtConnectorLib/settings.gradle
+++ b/BtConnectorLib/settings.gradle
@@ -1,3 +1,3 @@
 include ':btconnectorlib2'
-gradle.ext.version = "0.2.9";
+gradle.ext.version = "0.3.0";
 gradle.ext.group = "org.thaliproject.p2p.btconnectorlib"

--- a/BtConnectorLib/settings.gradle
+++ b/BtConnectorLib/settings.gradle
@@ -1,3 +1,3 @@
 include ':btconnectorlib2'
-gradle.ext.version = "0.2.7";
+gradle.ext.version = "0.2.8";
 gradle.ext.group = "org.thaliproject.p2p.btconnectorlib"

--- a/NativeTestApp/app/build.gradle
+++ b/NativeTestApp/app/build.gradle
@@ -39,5 +39,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile(group: 'org.thaliproject.p2p.btconnectorlib', name: 'btconnectorlib2', version: '0.2.7', ext: 'aar')
+    compile(group: 'org.thaliproject.p2p.btconnectorlib', name: 'btconnectorlib2', version: '0.2.8', ext: 'aar')
 }

--- a/NativeTestApp/app/build.gradle
+++ b/NativeTestApp/app/build.gradle
@@ -39,5 +39,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile(group: 'org.thaliproject.p2p.btconnectorlib', name: 'btconnectorlib2', version: '0.2.9', ext: 'aar')
+    compile(group: 'org.thaliproject.p2p.btconnectorlib', name: 'btconnectorlib2', version: '0.3.0', ext: 'aar')
 }

--- a/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/ConnectionEngine.java
+++ b/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/ConnectionEngine.java
@@ -9,7 +9,6 @@ import android.bluetooth.BluetoothSocket;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager;
-import android.os.Build;
 import android.os.CountDownTimer;
 import android.os.Handler;
 import android.support.v4.app.ActivityCompat;
@@ -38,9 +37,8 @@ public class ConnectionEngine implements
 
     // Service type and UUID has to be application/service specific.
     // The app will only connect to peers with the matching values.
-    public static final String PEER_NAME = Build.MANUFACTURER + "_" + Build.MODEL; // Use manufacturer and device model name as the peer name
     protected static final String SERVICE_TYPE = "ThaliTestSampleApp._tcp";
-    protected static final String SERVICE_UUID_AS_STRING = "9ab3c173-66d5-4da6-9e23-e8ce520b479b";
+    protected static final String SERVICE_UUID_AS_STRING = "b6a44ad1-d319-4b3a-815d-8b805a47fb51";
     protected static final String SERVICE_NAME = "Thali Test Sample App";
     protected static final UUID SERVICE_UUID = UUID.fromString(SERVICE_UUID_AS_STRING);
     protected static final long CHECK_CONNECTIONS_INTERVAL_IN_MILLISECONDS = 10000;
@@ -69,10 +67,7 @@ public class ConnectionEngine implements
         mModel = PeerAndConnectionModel.getInstance();
 
         mConnectionManager = new ConnectionManager(mContext, this, SERVICE_UUID, SERVICE_NAME);
-        mConnectionManager.setPeerName(PEER_NAME);
-
         mDiscoveryManager = new DiscoveryManager(mContext, this, SERVICE_UUID, SERVICE_TYPE);
-        mDiscoveryManager.setPeerName(PEER_NAME);
     }
 
     /**

--- a/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/ConnectionEngine.java
+++ b/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/ConnectionEngine.java
@@ -39,7 +39,7 @@ public class ConnectionEngine implements
     // The app will only connect to peers with the matching values.
     protected static final String SERVICE_TYPE = "ThaliTestSampleApp._tcp";
     protected static final String SERVICE_UUID_AS_STRING = "b6a44ad1-d319-4b3a-815d-8b805a47fb51";
-    protected static final String SERVICE_NAME = "Thali Test Sample App";
+    protected static final String SERVICE_NAME = "Thali_Bluetooth";
     protected static final UUID SERVICE_UUID = UUID.fromString(SERVICE_UUID_AS_STRING);
     protected static final long CHECK_CONNECTIONS_INTERVAL_IN_MILLISECONDS = 10000;
     protected static final long RESTART_CONNECTION_MANAGER_DELAY_IN_MILLISECONDS = 10000;

--- a/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/fragments/SettingsFragment.java
+++ b/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/fragments/SettingsFragment.java
@@ -15,6 +15,7 @@ import android.widget.*;
 import org.thaliproject.nativetest.app.ConnectionEngine;
 import org.thaliproject.nativetest.app.R;
 import org.thaliproject.nativetest.app.model.Settings;
+import org.thaliproject.p2p.btconnectorlib.internal.bluetooth.le.BlePeerDiscoverer;
 
 /**
  * A fragment for changing the application settings.
@@ -130,6 +131,30 @@ public class SettingsFragment extends Fragment {
                 mSettings.setEnableBleDiscovery(b);
             }
         });
+
+        RadioButton radioButton = (RadioButton) view.findViewById(R.id.serviceDataRadioButton);
+        radioButton.setOnClickListener(new AdapterView.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                mSettings.setAdvertisementDataType(BlePeerDiscoverer.AdvertisementDataType.SERVICE_DATA);
+            }
+        });
+
+        if (mSettings.getAdvertisementDataType() == BlePeerDiscoverer.AdvertisementDataType.SERVICE_DATA) {
+            radioButton.setChecked(true);
+        }
+
+        radioButton = (RadioButton) view.findViewById(R.id.manufacturerDataRadioButton);
+        radioButton.setOnClickListener(new AdapterView.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                mSettings.setAdvertisementDataType(BlePeerDiscoverer.AdvertisementDataType.MANUFACTURER_DATA);
+            }
+        });
+
+        if (mSettings.getAdvertisementDataType() == BlePeerDiscoverer.AdvertisementDataType.MANUFACTURER_DATA) {
+            radioButton.setChecked(true);
+        }
 
         Spinner spinner = (Spinner) view.findViewById(R.id.advertiseModeSpinner);
         ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(

--- a/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/fragments/SettingsFragment.java
+++ b/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/fragments/SettingsFragment.java
@@ -12,6 +12,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.*;
+import org.thaliproject.nativetest.app.ConnectionEngine;
 import org.thaliproject.nativetest.app.R;
 import org.thaliproject.nativetest.app.model.Settings;
 
@@ -27,6 +28,7 @@ public class SettingsFragment extends Fragment {
     private CheckBox mListenForIncomingConnectionsCheckbox = null;
     private CheckBox mEnableWifiCheckBox = null;
     private CheckBox mEnableBleCheckBox = null;
+    private EditText mPeerNameEditText = null;
     private EditText mBufferSizeEditText = null;
     private EditText mDataAmountEditText = null;
     private CheckBox mEnableAutoConnectCheckBox = null;
@@ -177,6 +179,32 @@ public class SettingsFragment extends Fragment {
 
             @Override
             public void onNothingSelected(AdapterView<?> adapterView) {
+            }
+        });
+
+        mPeerNameEditText = (EditText) view.findViewById(R.id.peerNameEditText);
+        mPeerNameEditText.setText(mSettings.getPeerName());
+        mPeerNameEditText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable editable) {
+                mSettings.setPeerName(editable.toString());
+            }
+        });
+
+        Button resetDefaultPeerNameButton = (Button) view.findViewById(R.id.resetDefaultPeerNameButton);
+        resetDefaultPeerNameButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                mSettings.setPeerName(Settings.DEFAULT_PEER_NAME);
+                mPeerNameEditText.setText(mSettings.getPeerName());
             }
         });
 

--- a/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/fragments/SettingsFragment.java
+++ b/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/fragments/SettingsFragment.java
@@ -156,6 +156,18 @@ public class SettingsFragment extends Fragment {
             radioButton.setChecked(true);
         }
 
+        radioButton = (RadioButton) view.findViewById(R.id.doNotCareRadioButton);
+        radioButton.setOnClickListener(new AdapterView.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                mSettings.setAdvertisementDataType(BlePeerDiscoverer.AdvertisementDataType.DO_NOT_CARE);
+            }
+        });
+
+        if (mSettings.getAdvertisementDataType() == BlePeerDiscoverer.AdvertisementDataType.DO_NOT_CARE) {
+            radioButton.setChecked(true);
+        }
+
         Spinner spinner = (Spinner) view.findViewById(R.id.advertiseModeSpinner);
         ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(
                 view.getContext(), R.array.advertise_mode_string_array, android.R.layout.simple_spinner_item);

--- a/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/model/Settings.java
+++ b/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/model/Settings.java
@@ -5,9 +5,11 @@ package org.thaliproject.nativetest.app.model;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.util.Log;
+import org.thaliproject.nativetest.app.ConnectionEngine;
 import org.thaliproject.p2p.btconnectorlib.ConnectionManager;
 import org.thaliproject.p2p.btconnectorlib.ConnectionManagerSettings;
 import org.thaliproject.p2p.btconnectorlib.DiscoveryManager;
@@ -23,6 +25,7 @@ public class Settings {
     private final SharedPreferences mSharedPreferences;
     private final SharedPreferences.Editor mSharedPreferencesEditor;
 
+    public static final String DEFAULT_PEER_NAME = Build.MANUFACTURER + "_" + Build.MODEL; // Use manufacturer and device model name as the peer name
     private static final boolean DEFAULT_LISTEN_FOR_INCOMING_CONNECTIONS = true;
     private static final boolean DEFAULT_ENABLE_WIFI_DISCOVERY = false;
     private static final boolean DEFAULT_ENABLE_BLE_DISCOVERY = true;
@@ -32,6 +35,7 @@ public class Settings {
     private static final String KEY_LISTEN_FOR_INCOMING_CONNECTIONS = "listen_for_incoming_connections";
     private static final String KEY_ENABLE_WIFI_DISCOVERY = "enable_wifi_discovery";
     private static final String KEY_ENABLE_BLE_DISCOVERY = "enable_ble_discovery";
+    private static final String KEY_PEER_NAME = "peer_name";
     private static final String KEY_DATA_AMOUNT = "data_amount";
     private static final String KEY_BUFFER_SIZE = "buffer_size";
     private static final String KEY_AUTO_CONNECT = "auto_connect";
@@ -45,6 +49,7 @@ public class Settings {
     private boolean mListenForIncomingConnections = true;
     private boolean mEnableWifiDiscovery = true;
     private boolean mEnableBleDiscovery = true;
+    private String mPeerName = DEFAULT_PEER_NAME;
     private long mDataAmountInBytes = Connection.DEFAULT_DATA_AMOUNT_IN_BYTES;
     private int mBufferSizeInBytes = Connection.DEFAULT_SOCKET_IO_THREAD_BUFFER_SIZE_IN_BYTES;
     private boolean mAutoConnect = false;
@@ -90,6 +95,7 @@ public class Settings {
             mEnableBleDiscovery = mSharedPreferences.getBoolean(
                     KEY_ENABLE_BLE_DISCOVERY, DEFAULT_ENABLE_BLE_DISCOVERY);
 
+            mPeerName = mSharedPreferences.getString(KEY_PEER_NAME, DEFAULT_PEER_NAME);
             mDataAmountInBytes = mSharedPreferences.getLong(KEY_DATA_AMOUNT, Connection.DEFAULT_DATA_AMOUNT_IN_BYTES);
             mBufferSizeInBytes = mSharedPreferences.getInt(
                     KEY_BUFFER_SIZE, Connection.DEFAULT_SOCKET_IO_THREAD_BUFFER_SIZE_IN_BYTES);
@@ -101,10 +107,14 @@ public class Settings {
                     + "\n    - Listen for incoming connections: " + mListenForIncomingConnections
                     + "\n    - Enable Wi-Fi Direct peer discovery: " + mEnableWifiDiscovery
                     + "\n    - Enable BLE peer discovery: " + mEnableBleDiscovery
+                    + "\n    - Peer name: " + mPeerName
                     + "\n    - Data amount in bytes: " + mDataAmountInBytes
                     + "\n    - Buffer size in bytes: " + mBufferSizeInBytes
                     + "\n    - Auto connect enabled: " + mAutoConnect
                     + "\n    - Auto connect even when incoming connection established: " + mAutoConnectEvenWhenIncomingConnectionEstablished);
+
+            mConnectionManager.setPeerName(mPeerName);
+            mDiscoveryManager.setPeerName(mPeerName);
 
             DiscoveryManager.DiscoveryMode discoveryMode = getDesiredDiscoveryMode();
 
@@ -266,6 +276,19 @@ public class Settings {
 
     public void setScanMode(int scanMode) {
         mDiscoveryManagerSettings.setScanMode(scanMode);
+    }
+
+    public String getPeerName() {
+        return mPeerName;
+    }
+
+    public void setPeerName(String peerName) {
+        if (mPeerName != peerName) {
+            mPeerName = peerName;
+            mSharedPreferencesEditor.putString(KEY_PEER_NAME, mPeerName);
+            mSharedPreferencesEditor.apply();
+            mConnectionManager.setPeerName(mPeerName);
+        }
     }
 
     /**

--- a/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/model/Settings.java
+++ b/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/model/Settings.java
@@ -14,6 +14,7 @@ import org.thaliproject.p2p.btconnectorlib.ConnectionManager;
 import org.thaliproject.p2p.btconnectorlib.ConnectionManagerSettings;
 import org.thaliproject.p2p.btconnectorlib.DiscoveryManager;
 import org.thaliproject.p2p.btconnectorlib.DiscoveryManagerSettings;
+import org.thaliproject.p2p.btconnectorlib.internal.bluetooth.le.BlePeerDiscoverer;
 
 /**
  * Manages the application settings.
@@ -252,6 +253,14 @@ public class Settings {
         mSharedPreferencesEditor.putBoolean(KEY_ENABLE_BLE_DISCOVERY, mEnableBleDiscovery);
         mSharedPreferencesEditor.apply();
         setDesiredDiscoveryMode();
+    }
+
+    public BlePeerDiscoverer.AdvertisementDataType getAdvertisementDataType() {
+        return mDiscoveryManagerSettings.getAdvertisementDataType();
+    }
+
+    public void setAdvertisementDataType(BlePeerDiscoverer.AdvertisementDataType advertisementDataType) {
+        mDiscoveryManagerSettings.setAdvertisementDataType(advertisementDataType);
     }
 
     public int getAdvertiseMode() {

--- a/NativeTestApp/app/src/main/res/layout/fragment_settings.xml
+++ b/NativeTestApp/app/src/main/res/layout/fragment_settings.xml
@@ -139,6 +139,28 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:singleLine="true"
+                        android:text="Peer name"
+                        android:textSize="@dimen/text_size_medium" />
+                <EditText
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingLeft="@dimen/padding_large"
+                        android:inputType="text"
+                        android:ems="10"
+                        android:id="@+id/peerNameEditText"/>
+            </LinearLayout>
+            <Button android:id="@+id/resetDefaultPeerNameButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="@dimen/default_padding"
+                    android:text="@string/reset_default" />
+            <LinearLayout android:layout_width="fill_parent"
+                          android:layout_height="match_parent"
+                          android:orientation="horizontal">
+                <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:singleLine="true"
                         android:text="Buffer size (bytes)"
                         android:textSize="@dimen/text_size_medium" />
                 <EditText

--- a/NativeTestApp/app/src/main/res/layout/fragment_settings.xml
+++ b/NativeTestApp/app/src/main/res/layout/fragment_settings.xml
@@ -91,6 +91,27 @@
                       android:layout_height="wrap_content"
                       android:text="Enable Bluetooth LE"
                       android:textSize="@dimen/text_size_medium" />
+            <TextView android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      android:paddingTop="@dimen/padding_small"
+                      android:singleLine="true"
+                      android:text="@string/advertisement_data_type"
+                      android:textSize="@dimen/text_size_medium" />
+            <RadioGroup xmlns:android="http://schemas.android.com/apk/res/android"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal">
+                <RadioButton android:id="@+id/serviceDataRadioButton"
+                             android:layout_width="wrap_content"
+                             android:layout_height="wrap_content"
+                             android:text="@string/service"
+                             android:onClick="onRadioButtonClicked" />
+                <RadioButton android:id="@+id/manufacturerDataRadioButton"
+                             android:layout_width="wrap_content"
+                             android:layout_height="wrap_content"
+                             android:text="@string/manufacturer"
+                             android:onClick="onRadioButtonClicked" />
+            </RadioGroup>
             <LinearLayout android:layout_width="fill_parent"
                           android:layout_height="wrap_content"
                           android:paddingRight="@dimen/list_item_padding"

--- a/NativeTestApp/app/src/main/res/layout/fragment_settings.xml
+++ b/NativeTestApp/app/src/main/res/layout/fragment_settings.xml
@@ -66,9 +66,9 @@
             <TextView android:layout_width="fill_parent"
                       android:layout_height="wrap_content"
                       android:paddingBottom="@dimen/padding_medium"
-                      android:singleLine="true"
+                      android:singleLine="false"
                       android:layout_marginLeft="6dp"
-                      android:text="Use -1 to let the platform decide or 0 for rotating port number"
+                      android:text="@string/rfcomm_port_info"
                       android:textSize="@dimen/text_size_small" />
             <CheckBox android:id="@+id/handshakeRequiredCheckBox"
                       android:layout_width="wrap_content"
@@ -111,7 +111,19 @@
                              android:layout_height="wrap_content"
                              android:text="@string/manufacturer"
                              android:onClick="onRadioButtonClicked" />
+                <RadioButton android:id="@+id/doNotCareRadioButton"
+                             android:layout_width="wrap_content"
+                             android:layout_height="wrap_content"
+                             android:text="@string/do_not_care"
+                             android:onClick="onRadioButtonClicked" />
             </RadioGroup>
+            <TextView android:layout_width="fill_parent"
+                      android:layout_height="wrap_content"
+                      android:paddingBottom="@dimen/padding_medium"
+                      android:singleLine="false"
+                      android:layout_marginLeft="6dp"
+                      android:text="@string/do_not_care_info"
+                      android:textSize="@dimen/text_size_small" />
             <LinearLayout android:layout_width="fill_parent"
                           android:layout_height="wrap_content"
                           android:paddingRight="@dimen/list_item_padding"
@@ -175,6 +187,13 @@
                     android:layout_height="wrap_content"
                     android:padding="@dimen/default_padding"
                     android:text="@string/reset_default" />
+            <TextView android:layout_width="fill_parent"
+                      android:layout_height="wrap_content"
+                      android:paddingBottom="@dimen/padding_medium"
+                      android:singleLine="false"
+                      android:layout_marginLeft="6dp"
+                      android:text="@string/peer_name_info"
+                      android:textSize="@dimen/text_size_small" />
             <LinearLayout android:layout_width="fill_parent"
                           android:layout_height="match_parent"
                           android:orientation="horizontal">

--- a/NativeTestApp/app/src/main/res/values/strings.xml
+++ b/NativeTestApp/app/src/main/res/values/strings.xml
@@ -28,5 +28,7 @@
         <item>SCAN_MODE_LOW_LATENCY</item>
     </string-array>
 
+    <string name="reset_default">Reset default</string>
+
     <string name="run_test">Run test</string>
 </resources>

--- a/NativeTestApp/app/src/main/res/values/strings.xml
+++ b/NativeTestApp/app/src/main/res/values/strings.xml
@@ -9,9 +9,12 @@
     <string name="action_start_bluetooth_device_discovery">Start Bluetooth device discovery</string>
     <string name="action_make_device_discoverable">Make device discoverable</string>
 
-    <string name="advertisement_data_type">Advertisement data type</string>
+    <string name="rfcomm_port_info">Use -1 to let the platform decide or 0 for rotating port number</string>
+    <string name="advertisement_data_type">Advertisement data type (BLE only)</string>
     <string name="service">service</string>
     <string name="manufacturer">manufacturer</string>
+    <string name="do_not_care">don\'t care</string>
+    <string name="do_not_care_info">In \"don\'t care\" mode, the data type to advertise will be \"service\", but \"manufacturer\" will be used as a fallback. The app will scan and parse both \"service\" and \"manufacturer\" data based advertisements.</string>
 
     <string-array name="advertise_mode_string_array">
         <item>ADVERTISE_MODE_LOW_POWER</item>
@@ -33,6 +36,7 @@
     </string-array>
 
     <string name="reset_default">Reset default</string>
+    <string name="peer_name_info">After changing the peer name restarting the app is required for the setting to take effect.</string>
 
     <string name="run_test">Run test</string>
 </resources>

--- a/NativeTestApp/app/src/main/res/values/strings.xml
+++ b/NativeTestApp/app/src/main/res/values/strings.xml
@@ -9,6 +9,10 @@
     <string name="action_start_bluetooth_device_discovery">Start Bluetooth device discovery</string>
     <string name="action_make_device_discoverable">Make device discoverable</string>
 
+    <string name="advertisement_data_type">Advertisement data type</string>
+    <string name="service">service</string>
+    <string name="manufacturer">manufacturer</string>
+
     <string-array name="advertise_mode_string_array">
         <item>ADVERTISE_MODE_LOW_POWER</item>
         <item>ADVERTISE_MODE_BALANCED</item>


### PR DESCRIPTION
- Workaround for service data issue: Will now fallback to using manufacturer data, if using service data fails.
- Using the simplified handshake message (matching CordovaPlugin) when no peer name is set.
- Added new settings to the Native Test application to test the advertisement data types and changing the peer name.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin_btlibrary/55)

<!-- Reviewable:end -->

<!---
@huboard:{"order":227.98790740966797,"milestone_order":55,"custom_state":""}
-->
