### PR TITLE
Get proper Bluetooth Mac Address on Android O

### DIFF
--- a/BtConnectorLib/btconnectorlib2/build.gradle
+++ b/BtConnectorLib/btconnectorlib2/build.gradle
@@ -25,7 +25,7 @@ android {
         unitTests.returnDefaultValues = true
     }
 
-    testBuildType "debug"
+    testBuildType "release"
 }
 
 dependencies {

--- a/BtConnectorLib/btconnectorlib2/build.gradle
+++ b/BtConnectorLib/btconnectorlib2/build.gradle
@@ -6,7 +6,7 @@ group = gradle.ext.group
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25"
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         minSdkVersion 21
@@ -25,7 +25,7 @@ android {
         unitTests.returnDefaultValues = true
     }
 
-    testBuildType "release"
+    testBuildType "debug"
 }
 
 dependencies {
@@ -34,6 +34,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile "org.mockito:mockito-core:1.9.5"
 
+    androidTestCompile 'com.android.support:support-annotations:24.0.0'
     androidTestCompile 'junit:junit:4.12'
     androidTestCompile 'com.android.support.test:runner:0.5'
     // dependency to use JUnit 4 rules

--- a/BtConnectorLib/btconnectorlib2/build.gradle
+++ b/BtConnectorLib/btconnectorlib2/build.gradle
@@ -24,6 +24,7 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
     }
+
     testBuildType "release"
 }
 

--- a/BtConnectorLib/btconnectorlib2/src/androidTest/java/org/thaliproject/p2p/btconnectorlib/AbstractConnectivityManagerTest.java
+++ b/BtConnectorLib/btconnectorlib2/src/androidTest/java/org/thaliproject/p2p/btconnectorlib/AbstractConnectivityManagerTest.java
@@ -4,8 +4,6 @@ import android.bluetooth.BluetoothAdapter;
 import android.net.wifi.WifiManager;
 import android.support.test.InstrumentationRegistry;
 
-import org.thaliproject.p2p.btconnectorlib.internal.wifi.WifiDirectManager;
-
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -27,14 +25,14 @@ public class AbstractConnectivityManagerTest {
         long currentTimeout = 0;
         while (currentTimeout < MAX_MEDIA_TIMEOUT) {
             if (btAdapter.getState() == BluetoothAdapter.STATE_ON ||
-                btAdapter.getState() == BluetoothAdapter.STATE_OFF) {
+                    btAdapter.getState() == BluetoothAdapter.STATE_OFF) {
                 break;
             }
             Thread.sleep(CHECK_MEDIA_INTERVAL);
             currentTimeout += CHECK_MEDIA_INTERVAL;
         }
         assertThat(btAdapter.getState(), anyOf(is(BluetoothAdapter.STATE_ON),
-                                               is(BluetoothAdapter.STATE_OFF)));
+                is(BluetoothAdapter.STATE_OFF)));
 
         if (turnOn && btAdapter.getState() == BluetoothAdapter.STATE_OFF) {
             btAdapter.enable();
@@ -62,7 +60,7 @@ public class AbstractConnectivityManagerTest {
 
     protected static void toggleWifi(boolean turnOn) throws Exception {
 
-        WifiManager wifiManager = (WifiManager) InstrumentationRegistry.getContext().getSystemService(
+        WifiManager wifiManager = (WifiManager) InstrumentationRegistry.getContext().getApplicationContext().getSystemService(
                 InstrumentationRegistry.getContext().WIFI_SERVICE);
 
         if (wifiManager == null) {

--- a/BtConnectorLib/btconnectorlib2/src/androidTest/java/org/thaliproject/p2p/btconnectorlib/ConnectionManagerTest.java
+++ b/BtConnectorLib/btconnectorlib2/src/androidTest/java/org/thaliproject/p2p/btconnectorlib/ConnectionManagerTest.java
@@ -1,7 +1,6 @@
 package org.thaliproject.p2p.btconnectorlib;
 
 import android.bluetooth.BluetoothAdapter;
-import android.bluetooth.IBluetooth;
 import android.content.Context;
 import android.os.CountDownTimer;
 import android.os.Looper;

--- a/BtConnectorLib/btconnectorlib2/src/androidTest/java/org/thaliproject/p2p/btconnectorlib/ConnectionManagerTest.java
+++ b/BtConnectorLib/btconnectorlib2/src/androidTest/java/org/thaliproject/p2p/btconnectorlib/ConnectionManagerTest.java
@@ -25,7 +25,6 @@ import org.thaliproject.p2p.btconnectorlib.utils.CommonUtils;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/BtConnectorLib/btconnectorlib2/src/androidTest/java/org/thaliproject/p2p/btconnectorlib/ConnectionManagerTest.java
+++ b/BtConnectorLib/btconnectorlib2/src/androidTest/java/org/thaliproject/p2p/btconnectorlib/ConnectionManagerTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
 public class ConnectionManagerTest extends AbstractConnectivityManagerTest {

--- a/BtConnectorLib/btconnectorlib2/src/androidTest/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManagerTest.java
+++ b/BtConnectorLib/btconnectorlib2/src/androidTest/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManagerTest.java
@@ -1024,8 +1024,6 @@ public class DiscoveryManagerTest extends AbstractConnectivityManagerTest {
         Field mBlePeerDiscovererField = mDiscoveryManager.getClass().getDeclaredField("mBlePeerDiscoverer");
         CommonUtils.setMockedValue(mBlePeerDiscovererField, mDiscoveryManager, mMockBlePeerDiscoverer);
 
-        // We skip AbstractBluetoothConnectivityAgent.verifyBluetoothMacAddress and return
-        // wrong mac address directly
         when(mMockBluetoothManager.getBluetoothMacAddress()).thenReturn("0:0:0:0:0:0");
         when(mMockBluetoothManager.isBluetoothEnabled()).thenReturn(true);
         when(mMockBluetoothManager.isBleSupported()).thenReturn(true);

--- a/BtConnectorLib/btconnectorlib2/src/androidTest/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManagerTest.java
+++ b/BtConnectorLib/btconnectorlib2/src/androidTest/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManagerTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 public class DiscoveryManagerTest extends AbstractConnectivityManagerTest {
 
     private DiscoveryManager mDiscoveryManager = null;
+    private BluetoothAdapter mBluetoothAdapter = null;
     private static DiscoveryManager.DiscoveryMode defaultDiscoveryMode;
     private static boolean defaultBTStatus;
     private static boolean defaultWifiStatus;
@@ -141,6 +142,10 @@ public class DiscoveryManagerTest extends AbstractConnectivityManagerTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
+
+        // Make sure that BluetoothManagerService is initialized
+        mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+
         toggleBluetooth(false);
         toggleWifi(false);
 

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManager.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManager.java
@@ -493,7 +493,6 @@ public class DiscoveryManager
             if (bluetoothEnabled) {
                 // Try to start BLE based discovery
                 mBluetoothMacAddressResolutionHelper.stopBluetoothDeviceDiscovery();
-
                 if (mBluetoothManager.isBleSupported()) {
                     bleDiscoveryStarted = startBlePeerDiscoverer();
                 } else {

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/AbstractBluetoothConnectivityAgent.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/AbstractBluetoothConnectivityAgent.java
@@ -27,7 +27,6 @@ public abstract class AbstractBluetoothConnectivityAgent implements BluetoothMan
     protected final Context mContext;
     protected final BluetoothManager mBluetoothManager;
     protected String mMyIdentityString = null;
-    protected boolean mEmulateMarshmallow = false;
     protected int myExtraInfo = PeerProperties.NO_EXTRA_INFORMATION;
 
     /**
@@ -86,21 +85,6 @@ public abstract class AbstractBluetoothConnectivityAgent implements BluetoothMan
     }
 
     /**
-     * Used for testing purposes.
-     * <p>
-     * Turns Marshmallow emulation on/off. Basically what this does is that if enabled, will not be
-     * able to resolve the Bluetooth MAC address of the device from the Bluetooth adapter.
-     *
-     * @param emulate If true, will turn on Marshmallow emulation.
-     */
-    public void setEmulateMarshmallow(boolean emulate) {
-        if (mEmulateMarshmallow != emulate) {
-            mEmulateMarshmallow = emulate;
-            Log.i(TAG, "setEmulateMarshmallow: " + mEmulateMarshmallow);
-        }
-    }
-
-    /**
      * @return The Bluetooth MAC address or null, if not available.
      */
     public String getBluetoothMacAddress() {
@@ -114,7 +98,6 @@ public abstract class AbstractBluetoothConnectivityAgent implements BluetoothMan
      * @return The Bluetooth MAC address or null, if not available.
      */
     public String getBluetoothMacAddress(SharedPreferences preferences) {
-
         DiscoveryManagerSettings settings = DiscoveryManagerSettings.getInstance(mContext, preferences);
 
         return verifyBluetoothMacAddress(settings);
@@ -122,7 +105,8 @@ public abstract class AbstractBluetoothConnectivityAgent implements BluetoothMan
 
     @Nullable
     private String verifyBluetoothMacAddress(DiscoveryManagerSettings settings) {
-        String bluetoothMacAddress = mEmulateMarshmallow ? null : mBluetoothManager.getBluetoothMacAddress();
+        String bluetoothMacAddress = mBluetoothManager.getBluetoothMacAddress();
+
         if (settings != null) {
             if (bluetoothMacAddress == null) {
                 bluetoothMacAddress = settings.getBluetoothMacAddress();

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothManager.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothManager.java
@@ -417,9 +417,10 @@ public class BluetoothManager {
             try {
                 Field mServiceField = mBluetoothAdapter.getClass().getDeclaredField("mService");
                 mServiceField.setAccessible(true);
+
                 Object btManagerService = mServiceField.get(mBluetoothAdapter);
-                Method mMethod = btManagerService.getClass().getMethod("getAddress");
-                bluetoothMacAddress = (String) mMethod.invoke(btManagerService);
+
+                bluetoothMacAddress = (String) btManagerService.getClass().getMethod("getAddress").invoke(btManagerService);
             } catch (NoSuchFieldException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
                 Log.e(TAG, "getBluetoothMacAddress: Failed to get Bluetooth address " + e.getMessage(), e);
             }

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothManager.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothManager.java
@@ -18,7 +18,6 @@ import org.thaliproject.p2p.btconnectorlib.utils.CommonUtils;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothManager.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothManager.java
@@ -419,7 +419,9 @@ public class BluetoothManager {
 
                 Object btManagerService = mServiceField.get(mBluetoothAdapter);
 
-                bluetoothMacAddress = (String) btManagerService.getClass().getMethod("getAddress").invoke(btManagerService);
+                if (btManagerService != null) {
+                    bluetoothMacAddress = (String) btManagerService.getClass().getMethod("getAddress").invoke(btManagerService);
+                }
             } catch (NoSuchFieldException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
                 Log.e(TAG, "getBluetoothMacAddress: Failed to get Bluetooth address " + e.getMessage(), e);
             }

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/utils/CommonUtils.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/utils/CommonUtils.java
@@ -11,6 +11,8 @@ import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import org.thaliproject.p2p.btconnectorlib.internal.bluetooth.BluetoothUtils;
 
+import java.lang.reflect.Field;
+
 /**
  * Commonly used utils and constants.
  */
@@ -65,6 +67,24 @@ public class CommonUtils {
      */
     public static boolean isValidBluetoothMacAddress(String bluetoothMacAddress) {
         return BluetoothUtils.isValidBluetoothMacAddress(bluetoothMacAddress);
+    }
+
+    /**
+     * Used to replace original instance with our mocked one. Assumes that field has
+     * modifiers such as final, static or private and by setting proper accessFlags,
+     * gets rid of them. This allows to replace it using reflection mechnisms.
+     * @throws Exception
+     */
+    public static void setMockedValue(Field originalField, Object parentObject, Object newValue) throws Exception {
+        //Field field = mConnectionManager.getClass().getSuperclass().getDeclaredField("mBluetoothManager");
+        originalField.setAccessible(true);
+
+        // Makes field only 'public'
+        Field slotField = Field.class.getDeclaredField("accessFlags");
+        slotField.setAccessible(true);
+        slotField.set(originalField, 1);
+
+        originalField.set(parentObject, newValue);
     }
 
     /**

--- a/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/utils/CommonUtils.java
+++ b/BtConnectorLib/btconnectorlib2/src/main/java/org/thaliproject/p2p/btconnectorlib/utils/CommonUtils.java
@@ -27,7 +27,7 @@ public class CommonUtils {
     }
 
     /**
-     * @return True, if we are running on Marshmallow (Android version 6.x) or higher. False otehrwise.
+     * @return True, if we are running on Marshmallow (Android version 6.x) or higher. False otherwise.
      */
     public static boolean isMarshmallowOrHigher() {
         return (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1);

--- a/BtConnectorLib/btconnectorlib2/src/test/java/org/thaliproject/p2p/btconnectorlib/ConnectionManagerTest.java
+++ b/BtConnectorLib/btconnectorlib2/src/test/java/org/thaliproject/p2p/btconnectorlib/ConnectionManagerTest.java
@@ -11,9 +11,11 @@ import android.os.Handler;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.thaliproject.p2p.btconnectorlib.internal.bluetooth.BluetoothConnector;
 import org.thaliproject.p2p.btconnectorlib.internal.bluetooth.BluetoothManager;
@@ -38,6 +40,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class ConnectionManagerTest {
 
     @Mock

--- a/BtConnectorLib/btconnectorlib2/src/test/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManagerSettingsTest.java
+++ b/BtConnectorLib/btconnectorlib2/src/test/java/org/thaliproject/p2p/btconnectorlib/DiscoveryManagerSettingsTest.java
@@ -89,7 +89,6 @@ public class DiscoveryManagerSettingsTest {
 
             @Override
             public SharedPreferences.Editor putLong(String key, long value) {
-
                 mSharedPreferencesMap.put(key, value);
 
                 return null;

--- a/BtConnectorLib/btconnectorlib2/src/test/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothConnectorTest.java
+++ b/BtConnectorLib/btconnectorlib2/src/test/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothConnectorTest.java
@@ -11,7 +11,6 @@ import android.os.Handler;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/BtConnectorLib/btconnectorlib2/src/test/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothUtilsTest.java
+++ b/BtConnectorLib/btconnectorlib2/src/test/java/org/thaliproject/p2p/btconnectorlib/internal/bluetooth/BluetoothUtilsTest.java
@@ -3,7 +3,6 @@ package org.thaliproject.p2p.btconnectorlib.internal.bluetooth;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothSocket;
 
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,7 +12,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.thaliproject.p2p.btconnectorlib.PeerProperties;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;

--- a/BtConnectorLib/build.gradle
+++ b/BtConnectorLib/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/BtConnectorLib/gradle/wrapper/gradle-wrapper.properties
+++ b/BtConnectorLib/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Dec 23 18:34:22 MSK 2016
+#Wed Aug 23 10:15:53 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/NativeTestApp/app/build.gradle
+++ b/NativeTestApp/app/build.gradle
@@ -39,5 +39,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile(group: 'org.thaliproject.p2p.btconnectorlib', name: 'btconnectorlib2', version: '0.3.8', ext: 'aar')
+    compile(group: 'org.thaliproject.p2p.btconnectorlib', name: 'btconnectorlib2', version: '0.3.9', ext: 'aar')
 }

--- a/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/test/FindMyBluetoothAddressTest.java
+++ b/NativeTestApp/app/src/main/java/org/thaliproject/nativetest/app/test/FindMyBluetoothAddressTest.java
@@ -50,8 +50,6 @@ public class FindMyBluetoothAddressTest
         mDiscoveryManager.setEmulateMarshmallow(true);
         //}
 
-        DiscoveryManagerSettings settings = DiscoveryManagerSettings.getInstance(null);
-
         try {
             Field mBluetoothMacAddressResolutionHelperField = mDiscoveryManager.getClass().getDeclaredField("mBluetoothMacAddressResolutionHelper");
             mBluetoothMacAddressResolutionHelperField.setAccessible(true);
@@ -69,12 +67,6 @@ public class FindMyBluetoothAddressTest
             mStoredBluetoothMacAddress = (String) btManagerService.getClass().getMethod("getAddress").invoke(btManagerService);
         } catch (NoSuchFieldException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
             e.printStackTrace();
-        }
-
-        if (mStoredBluetoothMacAddress != null) {
-            // Clear the Bluetooth MAC address, but store it so it can be restored later in case the
-            // test fails
-            settings.clearBluetoothMacAddress();
         }
 
         mDiscoveryManager.clearIdentityString();


### PR DESCRIPTION
Not sure about instrumented tests adjustment, I was unable to run it. 
Tested also on Android 6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin_btlibrary/111)
<!-- Reviewable:end -->
